### PR TITLE
Custom colour palette

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -1,4 +1,5 @@
 @import 'page-colours';
+@import 'user-colour-palette';
 
 //mixins
 @mixin hale-heading-link-underline-restrictor($colour, $width: 1024px) {

--- a/assets/scss/user-colour-palette.scss
+++ b/assets/scss/user-colour-palette.scss
@@ -6,7 +6,7 @@
 // Solves the issue of WordPress not knowing whether our custom colours are dark or light
 // This colours the tick in a way which should always have some contrast against the background
 // But there are always problem colours
-// Only acts on custom colours)
+// Only acts on custom colours
 @mixin brand-palette-colour($index) {
 	button[aria-label="Color: Branded colour #{$index}"]+svg>path {
 		color: var(--generic-palette-#{$index});

--- a/assets/scss/user-colour-palette.scss
+++ b/assets/scss/user-colour-palette.scss
@@ -1,0 +1,21 @@
+/***
+* This file deals with the user-enabled
+* colour picker found in WordPress 6.2+
+*/
+
+// Solves the issue of WordPress not knowing whether our custom colours are dark or light
+// This colours the tick in a way which should always have some contrast against the background
+// But there are always problem colours
+// Only acts on custom colours)
+@mixin brand-palette-colour($index) {
+	button[aria-label="Color: Branded colour #{$index}"]+svg>path {
+		color: var(--generic-palette-#{$index});
+		fill: currentColor;
+  		filter: invert(1) hue-rotate(230deg) contrast(200%) brightness(150%);
+	}
+}
+
+@include brand-palette-colour($index: 1);
+@include brand-palette-colour($index: 2);
+@include brand-palette-colour($index: 3);
+@include brand-palette-colour($index: 4);

--- a/assets/scss/user-colour-palette.scss
+++ b/assets/scss/user-colour-palette.scss
@@ -11,7 +11,7 @@
 	button[aria-label="Color: Branded colour #{$index}"]+svg>path {
 		color: var(--generic-palette-#{$index});
 		fill: currentColor;
-  		filter: invert(1) hue-rotate(230deg) contrast(200%) brightness(150%);
+		filter: invert(1) hue-rotate(230deg) contrast(200%) brightness(150%);
 	}
 }
 
@@ -19,3 +19,13 @@
 @include brand-palette-colour($index: 2);
 @include brand-palette-colour($index: 3);
 @include brand-palette-colour($index: 4);
+
+// This block of text unsets the text colour which is set in moj-blocks-general.scss
+// where the other GDS styling is brought in.
+.govuk-main-wrapper .has-text-color {
+	p:not([class]), p[class=""],
+	ul:not([class]), ul[class=""],
+	ol:not([class]), ol[class=""] {
+	  color: unset;
+	}
+}

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -5,12 +5,17 @@
 		$white = '#FFF';
 		$black = '#0B0C0C';
 		$yellow = '#FD0';
+		$orange = '#F47738';
 		$red = '#D4351C';
 		$darkRed = '#942514';
 		$blue = '#1D70B8';
+		$lightBlue = '#5694CA';
 		$darkBlue = '#003078';
 		$purple = '#4C2C92';
+		$brightPurple = '#912B88';
+		$lightPink = '#F499BE';
 		$green = '#00703C';
+		$lightGreen = '#85994b';
 		$buttonHoverGreen = '#005A30';
 		$buttonHoverGrey = '#DBDAD9';
 		$lightGrey = '#F3F2F1';
@@ -187,9 +192,9 @@
 			['cookie-toggle-text',$white,'Cookie toggle text','',''],
 
 			//Generic colours - for WP6.2+ colour palette
-			['generic-palette-1',$yellow,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
-			['generic-palette-2',$currentPageBlue,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
-			['generic-palette-3',$red,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-1',$lightPink,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-2',$red,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-3',$orange,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
 			['generic-palette-4',$green,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
 		);
 

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -185,6 +185,12 @@
 			['cookie-toggle-bg',$green,'Cookie toggle background','',''],
 			['cookie-toggle-focus-bg',$buttonHoverGreen,'Cookie toggle focus background','',''],
 			['cookie-toggle-text',$white,'Cookie toggle text','',''],
+
+			//Generic colours - for WP6.2+ colour palette
+			['generic-palette-1',$buttonHoverGrey,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
+			['generic-palette-2',$currentPageBlue,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
+			['generic-palette-3',$red,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
+			['generic-palette-4',$green,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
 		);
 
 		return $colour_array;

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -187,10 +187,10 @@
 			['cookie-toggle-text',$white,'Cookie toggle text','',''],
 
 			//Generic colours - for WP6.2+ colour palette
-			['generic-palette-1',$buttonHoverGrey,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
-			['generic-palette-2',$currentPageBlue,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
-			['generic-palette-3',$red,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
-			['generic-palette-4',$green,'Colour for editor palette','Choose 4 colours, mix some light (background) and dark (text) ones',''],
+			['generic-palette-1',$yellow,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-2',$currentPageBlue,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-3',$red,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-4',$green,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
 		);
 
 		return $colour_array;

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -192,10 +192,10 @@
 			['cookie-toggle-text',$white,'Cookie toggle text','',''],
 
 			//Generic colours - for WP6.2+ colour palette
-			['generic-palette-1',$lightPink,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
-			['generic-palette-2',$red,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
-			['generic-palette-3',$orange,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
-			['generic-palette-4',$green,'Colour for editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-1',$lightPink,'Colour for block editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-2',$red,'Colour for block editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-3',$orange,'Colour for block editor palette','Avoid greyscale colours as a selection of these are always available',''],
+			['generic-palette-4',$green,'Colour for block editor palette','Avoid greyscale colours as a selection of these are always available',''],
 		);
 
 		return $colour_array;

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -6,7 +6,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
 
     $restrict_blocks = get_theme_mod('restrict_blocks', 1);
 
-    if($restrict_blocks || $restrict_blocks == "yes") { //old way to be deleted once new settings saved
+    if($restrict_blocks || $restrict_blocks == "yes") {
         $allowed_blocks = array(
             // Text blocks
             'core/code',

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -7,7 +7,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
     $restrict_blocks = get_theme_mod('restrict_blocks', 1);
 
     if($restrict_blocks || $restrict_blocks == "yes") { //old way to be deleted once new settings saved
-
+        $allowed_blocks = array(
             // Text blocks
             'core/code',
             'core/footnotes',
@@ -51,6 +51,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
             'mojblocks/reveal',
             'mojblocks/separator',
             'mojblocks/staggered-box'
+        );
 
         //Check if news post type is deactivated
         $cpt_news_activated = get_theme_mod('cpt_news_activated', 0);

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -18,6 +18,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
             'core/table',
 
             // Media blocks
+            'core/cover',
             'core/file',
             'core/image',
             'core/video',

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -21,6 +21,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
             'core/cover',
             'core/file',
             'core/image',
+            'core/media-text',
             'core/video',
 
             // Design blocks

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -8,26 +8,36 @@ function hale_allowed_block_types( $allowed_blocks ) {
 
     if($restrict_blocks || $restrict_blocks == "yes") { //old way to be deleted once new settings saved
 
-        $allowed_blocks = array(
-            'core/image',
-            'core/paragraph',
+            // Text blocks
+            'core/code',
+            'core/footnotes',
             'core/heading',
             'core/list',
             'core/list-item',
-            'core/code',
+            'core/paragraph',
+            'core/table',
+
+            // Media blocks
             'core/file',
+            'core/image',
             'core/video',
+
+            // Design blocks
+            'core/buttons',
+            'core/button',
             'core/columns',
             'core/group',
             'core/spacer',
+
+            // Widgets
             'core/legacy-widget',
             'core/social-links',
             'core/social-link',
+
+            // Embeds
             'core/embed',
-            'core/button',
-            'core/buttons',
-            'core/table',
-            'core/footnotes',
+
+            // MoJ blocks
             'mojblocks/accordion',
             'mojblocks/accordion-section',
             'mojblocks/banner',
@@ -37,10 +47,9 @@ function hale_allowed_block_types( $allowed_blocks ) {
             'mojblocks/highlights-list',
             'mojblocks/intro',
             'mojblocks/quote',
-            'mojblocks/separator',
             'mojblocks/reveal',
+            'mojblocks/separator',
             'mojblocks/staggered-box'
-        );
 
         //Check if news post type is deactivated
         $cpt_news_activated = get_theme_mod('cpt_news_activated', 0);

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.19
+Version: 3.11.20
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe

--- a/theme.json
+++ b/theme.json
@@ -17,9 +17,19 @@
             "color": "#0B0C0C"
           },
           {
+            "name": "Dark grey",
+            "slug": "dark-grey",
+            "color": "#505A5F"
+          },
+          {
             "name": "Mid grey",
             "slug": "mid-grey",
             "color": "#B1B4B6"
+          },
+          {
+            "name": "Lighter grey",
+            "slug": "lightish-grey",
+            "color": "#DBDAD9"
           },
           {
             "name": "Light grey",

--- a/theme.json
+++ b/theme.json
@@ -5,10 +5,53 @@
         "custom": false,
         "customDuotone": false,
         "customGradient": false,
+        "defaultGradients": false,
+        "defaultPalette": false,
         "duotone": [],
         "gradients": [],
         "link": false,
-        "palette": []
+        "palette": [
+          {
+            "name": "Black",
+            "slug": "black",
+            "color": "#0B0C0C"
+          },
+          {
+            "name": "Mid grey",
+            "slug": "mid-grey",
+            "color": "#B1B4B6"
+          },
+          {
+            "name": "Light grey",
+            "slug": "light-grey",
+            "color": "#F3F2F1"
+          },
+          {
+            "name": "White",
+            "slug": "white",
+            "color": "#FFFFFF"
+          },
+          {
+            "name": "Branded colour 1",
+            "slug": "generic-palette-1",
+            "color": "var(--generic-palette-1)"
+          },
+          {
+            "name": "Branded colour 2",
+            "slug": "generic-palette-2",
+            "color": "var(--generic-palette-2)"
+          },
+          {
+            "name": "Branded colour 3",
+            "slug": "generic-palette-3",
+            "color": "var(--generic-palette-3)"
+          },
+          {
+            "name": "Branded colour 4",
+            "slug": "generic-palette-4",
+            "color": "var(--generic-palette-4)"
+          }
+        ]
       },
       "typography": {
         "textTransform": false


### PR DESCRIPTION
In light of the new colour picker being rolled out with WordPress 6.2+, this amends the palette of selectable colours:
- Removes the default palette
- Adds in a custom palette which includes:
  - GDS standard black #0B0C0C
  - A series of GDS-used greys (#505A5F, #B1B4B6, #DBDAD9, #F3F2F1)
  - White #FFFFFF
  - 4 colours which are changeable in the colour editor, but which default to:
    - GDS colour light pink #F499BE
    - GDS colour red #D4351C 
    - GDS colour orange #F47738
    - GDS colour green #00703C
- Adds in styling to improve contrast on the select tick for our custom colours.
  - WordPress automatically chooses a contrasting tick but for our custom colours it can't know which colour it is, so without this it would always render as white.

Also, this amends the approved block list:
- Cover block (`core/cover`) added
- Media and Text block (`core/media-text`) added
- Organised file to put blocks in the sections they appear in the editor interface