### PR TITLE
Group block background colour preliminary work

### DIFF
--- a/assets/scss/brandings-extended-core-blocks.scss
+++ b/assets/scss/brandings-extended-core-blocks.scss
@@ -1,12 +1,12 @@
 html.hale-colours-variable {
 	//Group Block
-	.wp-block-group{
+	.wp-block-group:not(.has-background) {
 		&.is-style-bleeding-background,
 		&.is-style-text-aligned,
 		&.is-style-faded-bleed {
 			background-color: var(--extended-block-group-bg);
 			&:before {
-				background: var(--extended-block-group-bg);
+				background-color: var(--extended-block-group-bg);
 			}
 		}
 	}

--- a/assets/scss/brandings-extended-core-blocks.scss
+++ b/assets/scss/brandings-extended-core-blocks.scss
@@ -6,7 +6,7 @@ html.hale-colours-variable {
 		&.is-style-faded-bleed {
 			background-color: var(--extended-block-group-bg);
 			&:before {
-				background-color: var(--extended-block-group-bg);
+				background-color: inherit;
 			}
 		}
 	}

--- a/assets/scss/brandings-extended-core-blocks.scss
+++ b/assets/scss/brandings-extended-core-blocks.scss
@@ -1,0 +1,10 @@
+html.hale-colours-variable {
+	//Group Block
+	.wp-block-group{
+		&.is-style-bleeding-background,
+		&.is-style-text-aligned,
+		&.is-style-faded-bleed {
+			background-color: var(--mojblocks-group-bg);
+		}
+	}
+}

--- a/assets/scss/brandings-extended-core-blocks.scss
+++ b/assets/scss/brandings-extended-core-blocks.scss
@@ -4,7 +4,7 @@ html.hale-colours-variable {
 		&.is-style-bleeding-background,
 		&.is-style-text-aligned,
 		&.is-style-faded-bleed {
-			background-color: var(--mojblocks-group-bg);
+			background-color: var(--extended-block-group-bg);
 		}
 	}
 }

--- a/assets/scss/brandings-extended-core-blocks.scss
+++ b/assets/scss/brandings-extended-core-blocks.scss
@@ -5,6 +5,9 @@ html.hale-colours-variable {
 		&.is-style-text-aligned,
 		&.is-style-faded-bleed {
 			background-color: var(--extended-block-group-bg);
+			&:before {
+				background: var(--extended-block-group-bg);
+			}
 		}
 	}
 }

--- a/assets/scss/custom-branding.scss
+++ b/assets/scss/custom-branding.scss
@@ -5,6 +5,7 @@
 
 // theme colours
 @import 'brandings';
+@import 'brandings-extended-core-blocks';
 @import 'brandings-mojblocks';
 @import 'brandings-cookies';
 

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -122,7 +122,10 @@
 			//Job listings
 			['job-item-bg',$white,'Job listing background','',''],
 			['job-item-border',$midGrey,'Job listing separating line','Should ideally match pagination separating line',''],
-			
+
+			//extended core blocks
+			['extended-block-group-bg',$white,'Group block default background','',''],
+
 			//mojblocks - these are usually things not found in GOV.UK sites
 			['mojblocks-accordion-section-title',$black,'Accordion titles','',''],
 			['mojblocks-accordion-section-shew',$blue,'Accordion show links','',''],

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -124,7 +124,7 @@
 			['job-item-border',$midGrey,'Job listing separating line','Should ideally match pagination separating line',''],
 
 			//extended core blocks
-			['extended-block-group-bg',$white,'Group block default background','',''],
+			['extended-block-group-bg',$white,'Group block default background','Non-default style only',''],
 
 			//mojblocks - these are usually things not found in GOV.UK sites
 			['mojblocks-accordion-section-title',$black,'Accordion titles','',''],

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.20
+Version: 3.11.21
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Adds a new colour option for group block background (non-default styles only).  

Defaults to white to ensure no unexpected changes, this is preliminary work ready for an MoJ Blocks repo deploy.  The classes needed to trigger the new styles are not yet there, but will be introduced in a subsequent MoJ Blocks PR.  