### PR TITLE
Removed footer complementary role

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -28,13 +28,13 @@ flush();
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
-        <div id="hale-footer-widgets" class="hale-footer__widgets" role="complementary">
+        <div id="hale-footer-widgets" class="hale-footer__widgets">
         <?php dynamic_sidebar( 'footer-area-one' ); ?>
         </div>
     </div>
 
     <div class="govuk-grid-column-one-half">
-        <div id="hale-footer-widgets" class="hale-footer__widgets" role="complementary">
+        <div id="hale-footer-widgets" class="hale-footer__widgets">
         <?php dynamic_sidebar( 'footer-area-two' ); ?>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.21
+Version: 3.11.23
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Removed the `role=complementary` from the two footer areas as advised by UserVision's accessibility review (pp18-19).