### PR TITLE
New tab link suffix

### DIFF
--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -36,11 +36,4 @@
 			border-bottom-style: none;
 		}
 	}
-
-	// Link suffixes
-	a[target=_blank]:after {
-		content:" (new tab link)";
-		opacity: 0.6;
-	}
-
 }

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -40,6 +40,7 @@
 	// Link suffixes
 	a[target=_blank]:after {
 		content:" (new tab link)";
+		opacity: 0.6;
 	}
 
 }

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -36,4 +36,10 @@
 			border-bottom-style: none;
 		}
 	}
+
+	// Link suffixes
+	a[target=_blank]:after {
+		content:" (new tab link)";
+	}
+
 }

--- a/header.php
+++ b/header.php
@@ -15,23 +15,10 @@
 	} else {
 		$style_class = "hale-colours-variable";
 	}
-
-	$opens_in_a_new_tab = trim(get_theme_mod("link_new_tab_text"));
-	if (!isset($opens_in_a_new_tab) || $opens_in_a_new_tab == "") {
-		$opens_in_a_new_tab = "";
-	} else {
-		$opens_in_a_new_tab = " ($opens_in_a_new_tab)";
-	}
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?> class="hale-page <?php printf($style_class); ?>">
 <head>
-
-	<style>
-		a[target=_blank]:after {
-			content: "<?php echo $opens_in_a_new_tab; ?>";
-		}
-	</style>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="theme" content="MOJ-hale-1.0.11">

--- a/header.php
+++ b/header.php
@@ -15,11 +15,18 @@
 	} else {
 		$style_class = "hale-colours-variable";
 	}
+
+	if (!isset($opens_in_a_new_tab)) $opens_in_a_new_tab = "(opens in a new tab)";
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?> class="hale-page <?php printf($style_class); ?>">
 <head>
 
+	<style>
+		a[target=_blank]:after {
+			content: "<?php echo $opens_in_a_new_tab; ?>";
+		}
+	</style>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="theme" content="MOJ-hale-1.0.11">

--- a/header.php
+++ b/header.php
@@ -16,7 +16,12 @@
 		$style_class = "hale-colours-variable";
 	}
 
-	if (!isset($opens_in_a_new_tab)) $opens_in_a_new_tab = "(opens in a new tab)";
+	$opens_in_a_new_tab = trim(get_theme_mod("link_new_tab_text"));
+	if (!isset($opens_in_a_new_tab) || $opens_in_a_new_tab == "") {
+		$opens_in_a_new_tab = "";
+	} else {
+		$opens_in_a_new_tab = " ($opens_in_a_new_tab)";
+	}
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?> class="hale-page <?php printf($style_class); ?>">

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -209,7 +209,7 @@ function hale_customize_register( $wp_customize ) {
         )
     );
 
-  /*
+	/*
 	 * Crown Copyright
 	 */
 	$wp_customize->add_setting(
@@ -494,6 +494,45 @@ function hale_customize_register( $wp_customize ) {
 		}
 
 	}
+
+	/*
+	 * ------------------------------------------------------------
+	 * SECTION: Links
+	 * ------------------------------------------------------------
+	 */
+	$wp_customize->add_section(
+		'section_links',
+		array(
+			'title'       => esc_html__( 'Links', 'hale' ),
+			'description' => esc_attr__( 'Customise your site\'s link options', 'hale' ),
+			'priority'    => 30,
+		)
+	);
+
+	/*
+	 * Display Featured image on post / page?
+	 */
+	$wp_customize->add_setting(
+		'link_new_tab_text',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'hale_sanitize_nohtml',
+		)
+	);
+
+	$wp_customize->add_control(
+		'link_new_tab_text',
+		array(
+			'label'       => esc_html__( 'Link suffix', 'hale' ),
+			'description' => esc_html__( 'What text should be added to the link if it opens in a new tab', 'hale' ),
+			'section'     => 'section_links',
+			'priority'    => '100',
+			'type'        => 'text',
+		)
+	);
+
+
+
 	/*
 	 * ------------------------------------------------------------
 	 * SECTION: Layout

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -240,3 +240,26 @@ function hale_clean_bad_content( $b_print = false ) {
 		echo $hale_post_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
+
+function hook_css() {
+	$opens_in_a_new_tab = trim(get_theme_mod("link_new_tab_text"));
+	if (!isset($opens_in_a_new_tab) || $opens_in_a_new_tab == "") {
+		$opens_in_a_new_tab = "";
+	} else {
+		$opens_in_a_new_tab = " ($opens_in_a_new_tab)";
+	}
+    ?>
+	<style>
+		.edit-post-visual-editor a[target=_blank]:after,
+		.hale-page a[target=_blank]:after {
+			content: "<?php echo $opens_in_a_new_tab; ?>";
+		}
+
+		.edit-post-visual-editor a[target=_blank]:after {
+			opacity: 0.7;
+		}
+	</style>
+    <?php
+}
+add_action('wp_head', 'hook_css');
+add_action('admin_head', 'hook_css');


### PR DESCRIPTION
- New CSS style to label all links with `target="_blank"` as opening in a new tab.
  - The new style uses a PHP variable, so this is in the `<head>` tag rather than in an SCSS file.  
- New CSS style for edit page view, so editors can see this will have a suffix.  
  - This is a static bit of text "(new tab link)" so this can be in an SCSS file.  
  - This has an opacity of 0.6 so editors can see it is not an editable bit of text.
- Adds setting to customise the suffix, enabling different sites to use different text if needed.
  - It was noted that PPJ would use "open in a new tab" and NPM would use "open in a new window".
  - This is free text so can be anything.
  - This is a new section "Links".

## For rollout:
- The new setting won't be set yet on any page, so no links will have the suffix.  
- Someone will need to go through each page on a removing the manual "opens in a new tab" suffix.  
- Only once they are all removed can the text can be set in the new setting, otherwise the new automatic suffix will appear alongside the old suffix.  