### PR TITLE
Menu accessibility improvements

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -198,8 +198,8 @@ jQuery( document ).ready(function( $ ) {
 		} else {
 			$("#menu-menu-top-menu li.menu-item-has-children").removeClass("sub-menu-open");
 			menuItem.addClass("sub-menu-open");
-			let numberOfMenuItems = menuItem.find(".sub-menu > li").length + 1; // gets the number of menu options including the main link
-			$(this).height("calc("+numberOfMenuItems+" * (100% + 5px) )");
+			let subMenuItemsHeight = menuItem.find(".sub-menu").height();
+			$(this).height("calc(100% + 5px + "+subMenuItemsHeight+"px)");
 			$(this).attr("aria-expanded","true");
 		}
 	}).keydown(function(e){

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -163,19 +163,20 @@ jQuery( document ).ready(function( $ ) {
 		let openCloseControl = $(this).find(".hale-header__dropdown-arrow");
 
 		if (openCloseControl.is(":visible")) {
-			if (e.keyCode == "32") {
+			if (e.keyCode == "32") { // space
 				e.preventDefault();
 				openCloseControl.click();
 			}
-			if (e.keyCode == "40") {
+			if (e.keyCode == "13") { // return
+				openCloseControl.click();
+			}
+			if (e.keyCode == "40") { // down arrow
 				if (!$(this).parent().hasClass('sub-menu-open')) {
-					e.preventDefault();
 					openCloseControl.click();
 				}
 			}
-			if (e.keyCode == "38") {
+			if (e.keyCode == "38") { // up arrow
 				if ($(this).parent().hasClass('sub-menu-open')) {
-					e.preventDefault();
 					openCloseControl.click();
 				}
 			}
@@ -193,11 +194,13 @@ jQuery( document ).ready(function( $ ) {
 
 		if (menuItem.hasClass('sub-menu-open')) {
 			menuItem.removeClass("sub-menu-open");
+			$(this).attr("aria-expanded","false");
 		} else {
 			$("#menu-menu-top-menu li.menu-item-has-children").removeClass("sub-menu-open");
 			menuItem.addClass("sub-menu-open");
 			let numberOfMenuItems = menuItem.find(".sub-menu > li").length + 1; // gets the number of menu options including the main link
 			$(this).height("calc("+numberOfMenuItems+" * (100% + 5px) )");
+			$(this).attr("aria-expanded","true");
 		}
 	}).keydown(function(e){
 		if (e.keyCode == "13") $(this).click();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -154,7 +154,7 @@ jQuery( document ).ready(function( $ ) {
 	// We use JS to add a span that is used to tap on (mobile only) to shew the sub-menu, and is hidden by CSS on Desktop.
 
 	$( "#menu-menu-top-menu li.menu-item-has-children > a" ).append(
-		"<button class='hale-header__dropdown-arrow' aria-expanded='false'><span class='govuk-visually-hidden'>Display submenu</span></button>"
+		"<button class='hale-header__dropdown-arrow' aria-expanded='false'><span class='govuk-visually-hidden'>Show submenu</span></button>"
 	);
 
 	//Keyboard functionailty (requires mouse functionality)

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -154,7 +154,7 @@ jQuery( document ).ready(function( $ ) {
 	// We use JS to add a span that is used to tap on (mobile only) to shew the sub-menu, and is hidden by CSS on Desktop.
 
 	$( "#menu-menu-top-menu li.menu-item-has-children > a" ).append(
-		"<span tabindex='0' class='hale-header__dropdown-arrow'></span>"
+		"<button class='hale-header__dropdown-arrow' aria-expanded='false'><span class='govuk-visually-hidden'>Display submenu</span></button>"
 	);
 
 	//Keyboard functionailty (requires mouse functionality)

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -295,10 +295,16 @@
 					&.menu-item-has-children {
 						border-right-color: var(--header-divider-line);
 
-						> a:focus-within > .hale-header__dropdown-arrow:focus {
-								color: var(--header-link-hover-focus);
-								border-bottom: 4px solid var(--header-link-hover-focus);
-								background-color: var(--header-link-focus-highlight);
+						.hale-header__dropdown-arrow{
+							color: var(--header-link);
+							border:none;
+							background-color: var(--header-bg);
+
+							&:focus {
+									color: var(--header-link-hover-focus);
+									border-bottom: 4px solid var(--header-link-hover-focus);
+									background-color: var(--header-link-focus-highlight);
+							}
 						}
 
 						> a:after,

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -297,12 +297,15 @@
 
 						.hale-header__dropdown-arrow{
 							color: var(--header-link);
-							border:none;
 							background-color: var(--header-bg);
 
+							&:hover {
+									color: var(--header-link-hover);
+									border-bottom-color: var(--header-link-hover);
+							}
 							&:focus {
 									color: var(--header-link-hover-focus);
-									border-bottom: 4px solid var(--header-link-hover-focus);
+									border-bottom-color: var(--header-link-hover-focus);
 									background-color: var(--header-link-focus-highlight);
 							}
 						}

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -295,7 +295,7 @@
 					&.menu-item-has-children {
 						border-right-color: var(--header-divider-line);
 
-						> a:focus-within > span.hale-header__dropdown-arrow:focus {
+						> a:focus-within > .hale-header__dropdown-arrow:focus {
 								color: var(--header-link-hover-focus);
 								border-bottom: 4px solid var(--header-link-hover-focus);
 								background-color: var(--header-link-focus-highlight);

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -62,6 +62,47 @@
             margin-right: 0;
             border-right: none;
           }
+          .hale-header__dropdown-arrow {
+            display: inline-block;
+            position: absolute;
+            right: -60px;
+            top: 0;
+            width: 60px;
+            height: 37px;
+            //height: calc(100% + 0px);
+            border: 0;
+            border-bottom-width: 1px;
+            border-bottom-style: solid;
+            z-index: 20;
+            background-color: transparent;
+            cursor: pointer;
+            @include govuk-media-query($from: tablet) {
+              height: 41px;
+            }
+            @include govuk-media-query($from: desktop) {
+              display:none;
+            }
+
+            &:focus {
+              outline: none;
+            }
+
+            &:after {
+              border-color: currentcolor;
+              border-style: solid;
+              border-width: 0 3px 3px 0;
+              content: "";
+              display: block;
+              float: left;
+              margin: 3px 10px 0 5px;
+              padding: 3px;
+              position: absolute;
+              right: 15px;
+              top: 10px;
+              transform: rotate(45deg);
+              -webkit-transform: rotate(45deg);
+            }
+          }
 
           > a,
           > a:link,
@@ -97,45 +138,6 @@
                 right: 7px;
               }
             }
-
-            > .hale-header__dropdown-arrow {
-              border-bottom-width: 1px;
-              border-bottom-style: solid;
-              position: absolute;
-              z-index: 20;
-              top: 0;
-              right: -60px;
-              width: 60px;
-              height: 37px;
-              background-color: transparent;
-              cursor: pointer;
-              @include govuk-media-query($from: tablet) {
-                height: 41px;
-              }
-              @include govuk-media-query($from: desktop) {
-                display:none;
-              }
-            }
-
-            &:focus-within > .hale-header__dropdown-arrow:focus {
-              outline: none;
-
-              &:after {
-                border-color: currentcolor;
-                border-style: solid;
-                border-width: 0 3px 3px 0;
-                content: "";
-                display: block;
-                float: left;
-                margin: 3px 10px 0 5px;
-                padding: 3px;
-                position: absolute;
-                right: 15px;
-                top: 10px;
-                transform: rotate(45deg);
-                -webkit-transform: rotate(45deg);
-              }
-            }
           }
           @include govuk-media-query($from: desktop) {
             &:hover,
@@ -148,7 +150,7 @@
 
           &.sub-menu-open {
             > a:after,
-            > a:focus-within > .hale-header__dropdown-arrow:focus:after {
+            .hale-header__dropdown-arrow:after {
                 transform: rotate(-135deg);
                 -webkit-transform: rotate(-135deg);
                 margin: 6px 10px 0 5px;

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -68,22 +68,29 @@
             right: -60px;
             top: 0;
             width: 60px;
-            height: 37px;
-            //height: calc(100% + 0px);
-            border: 0;
+            //height: 37px;
+            height: calc(100% + 5px);
+            border-width: 0;
             border-bottom-width: 1px;
             border-bottom-style: solid;
             z-index: 20;
             background-color: transparent;
             cursor: pointer;
-            @include govuk-media-query($from: tablet) {
-              height: 41px;
-            }
             @include govuk-media-query($from: desktop) {
               display:none;
             }
 
+            &:hover {
+              border-bottom-width: 4px;
+              border-bottom-style: solid;
+              height: calc(100% + 4px);
+              outline: none;
+            }
+
             &:focus {
+              border-bottom-width: 4px;
+              border-bottom-style: solid;
+              height: calc(100% + 4px);
               outline: none;
             }
 

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -170,7 +170,8 @@
           > a:link,
           > a:visited,
           > a:link:visited {
-            > .hale-header__dropdown-arrow {
+            > .hale-header__dropdown-arrow:not(:focus):not(:hover) {
+              // this removes the grey line from the bottom option, in line with the rest of the menu
               border-bottom-width: 0px;
             }
           }

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -98,7 +98,7 @@
               }
             }
 
-            > span.hale-header__dropdown-arrow {
+            > .hale-header__dropdown-arrow {
               border-bottom-width: 1px;
               border-bottom-style: solid;
               position: absolute;
@@ -117,7 +117,7 @@
               }
             }
 
-            &:focus-within > span.hale-header__dropdown-arrow:focus {
+            &:focus-within > .hale-header__dropdown-arrow:focus {
               outline: none;
 
               &:after {
@@ -148,7 +148,7 @@
 
           &.sub-menu-open {
             > a:after,
-            > a:focus-within > span.hale-header__dropdown-arrow:focus:after {
+            > a:focus-within > .hale-header__dropdown-arrow:focus:after {
                 transform: rotate(-135deg);
                 -webkit-transform: rotate(-135deg);
                 margin: 6px 10px 0 5px;
@@ -161,7 +161,7 @@
           > a:link,
           > a:visited,
           > a:link:visited {
-            > span.hale-header__dropdown-arrow {
+            > .hale-header__dropdown-arrow {
               border-bottom-width: 0px;
             }
           }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.24
+Version: 3.11.25
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
This PR starts to address points 1.4 and 1.7 on the recent accessibility review.  
These changes affect narrow displays (mobile) only.  

- span changed to button
- new `aria-expanded` attribute added to button
  - JavaScript added to control this
- style improvements
  - especially regarding menu items which wrap on mobile

No visual change or change in behaviour in the main, but this should address the inability of swipe gestures to navigate.  

I plan to push this to production for thorough testing.  