### PR TITLE
Search term retention

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -12,7 +12,7 @@
 if ( ! empty( get_search_query() ) ) {
 	$query = get_search_query();
 } else {
-	$query = 'Search';
+	$query = '';
 }
 
 if ( ! isset( $GLOBALS['hale_search_form_counter'] ) ) {
@@ -40,7 +40,7 @@ if ( ! isset( $GLOBALS['hale_search_form_counter'] ) ) {
 <div class="hale-header__search-wrap" <?php echo esc_attr( $wrap_search ); ?>>
 	<form class="hale-header__search-form hale-search-invisible-contrast-correction" <?php echo esc_attr( $search_form ); ?> action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get" role="search">
 		<label class="govuk-visually-hidden hale-search__hidden-search-label" for="<?php echo esc_attr( $search_field ); ?>"><?php esc_html_e( 'Search this website', 'hale' ); ?></label>
-		<input class="hale-search__input govuk-input" id="<?php echo esc_attr( $search_field ); ?>" name="s" type="search" placeholder="<?php echo esc_attr__( 'Search', 'hale' ); ?>">
+		<input class="hale-search__input govuk-input" id="<?php echo esc_attr( $search_field ); ?>" name="s" type="search" placeholder="<?php echo esc_attr__( 'Search', 'hale' ); ?>" value="<?php esc_html_e($query);?>">
 		<button class="hale-search__submit govuk-button govuk-button--secondary" type="submit">
 			<svg class="hale-icon hale-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 				<path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.27
+Version: 3.11.28
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Added a new `value` property to the search form and used the existing `$query` value to fill it.  Changed the no search term `$query` value from "Search" to "" so the value is blank should no search term be entered.  

It looks like `$query` was not used - perhaps a hang-on from a previous incarnation of the search page.  But I thought it made sense to use it here.  