### PR TITLE
Added placeholder colour

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -55,6 +55,10 @@
 	//search page only style (affects search in header but not adversely so
 	.hale-search__input {
 		margin-bottom: 30px;
+
+		&:focus::placeholder {
+			color:currentColor; // ensuring sufficient contrast against the focus background
+		}
 	}
 
 	.govuk-header {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.12.1
+Version: 3.12.2
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Added a placeholder colour style for focus state only
- Focus state has a custom background, so we use `currentColor` to ensure that the designed contrast is applied to the placeholder as well
- Non-focus state will have a white background so we don't need to have anything special for these situations.  