### PR TITLE
Quick exit button

### DIFF
--- a/assets/js/gov-overrides.js
+++ b/assets/js/gov-overrides.js
@@ -1,0 +1,17 @@
+//Overrides GOVUK exitPage function so it open in newtab
+if (typeof ExitThisPage === 'function') { //check ExitThisPage Class Exists
+  ExitThisPage.prototype.exitPage = function() {
+
+    //Loading Overlay copied from govuk
+    document.body.classList.add("govuk-exit-this-page-hide-content");
+    this.$overlay = document.createElement("div");
+    this.$overlay.className = "govuk-exit-this-page-overlay";
+    this.$overlay.setAttribute("role", "alert");
+    document.body.appendChild(this.$overlay);
+    this.$overlay.textContent = this.i18n.t("activated");
+
+    //Functionality to Open in new Tab
+    window.open("http://bbc.co.uk/weather", "_newtab");
+    window.location.replace("http://www.google.co.uk");  
+  };
+}

--- a/assets/js/hale-scripts.js
+++ b/assets/js/hale-scripts.js
@@ -17,11 +17,14 @@ if( document.getElementById("search-show-hide") != null) {
 
 jQuery( document ).ready(function( $ ) {
 
+
+  /*
   function fleeFromPage(fleeMethod) {
     $("body").hide();
     window.open("http://bbc.co.uk/weather", "_newtab");
     window.location.replace("http://www.google.co.uk");   
   }
+
   $("a.govuk-exit-this-page__button").on("click", function(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -30,18 +33,6 @@ jQuery( document ).ready(function( $ ) {
   $(document).keyup(function(e) {
     if (e.keyCode == 27) { // 27 = escape key
       fleeFromPage("escape key");
-    }
-  });
-
-  /*
-  window.addEventListener('scroll', function() {
-    var stickyDiv = document.getElementById('.govuk-exit-this-page');
-    var stickyDivRect = stickyDiv.getBoundingClientRect();
-  
-    if (window.scrollY >= stickyDivRect.top) {
-      stickyDiv.classList.add('sticky');
-    } else {
-      stickyDiv.classList.remove('sticky');
     }
   });*/
 

--- a/assets/js/hale-scripts.js
+++ b/assets/js/hale-scripts.js
@@ -14,3 +14,80 @@ if( document.getElementById("search-show-hide") != null) {
     }
   );
 }
+
+jQuery( document ).ready(function( $ ) {
+
+  function fleeFromPage(fleeMethod) {
+    $("body").hide();
+    window.open("http://bbc.co.uk/weather", "_newtab");
+    window.location.replace("http://www.google.co.uk");   
+  }
+  $("a.govuk-exit-this-page__button").on("click", function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    fleeFromPage("mouse click");
+  });
+  $(document).keyup(function(e) {
+    if (e.keyCode == 27) { // 27 = escape key
+      fleeFromPage("escape key");
+    }
+  });
+
+  /*
+  window.addEventListener('scroll', function() {
+    var stickyDiv = document.getElementById('.govuk-exit-this-page');
+    var stickyDivRect = stickyDiv.getBoundingClientRect();
+  
+    if (window.scrollY >= stickyDivRect.top) {
+      stickyDiv.classList.add('sticky');
+    } else {
+      stickyDiv.classList.remove('sticky');
+    }
+  });*/
+
+  $(window).on('scroll resize', function() {
+    var stickyDiv = $('.govuk-exit-this-page');
+    var stickyButton = $('.govuk-exit-this-page a');
+
+    if (stickyDiv.length) {
+
+      var divMinHeight = stickyButton.outerHeight();
+      var divMinWidth = stickyButton.outerWidth();
+
+      if ($(".hale-header__mobile-controls--search").is(":visible")) {
+        //divMinHeight = 'initial';
+        divMinWidth = 0
+      }
+
+      stickyDiv.css({
+        "min-height": divMinHeight,
+        "min-width": divMinWidth
+       });
+
+      var stickyDivTop = stickyDiv.offset().top;
+      var stickyDivLeft = stickyDiv.offset().left;
+
+      if ($(window).scrollTop() >= stickyDivTop) {
+        stickyDiv.addClass('sticky');
+
+        $('.govuk-exit-this-page a').css({
+            "left": stickyDivLeft
+        });
+
+      } else {
+        stickyDiv.removeClass('sticky');
+      
+        $('.govuk-exit-this-page a').css({
+            "left": 'initial'
+        });
+      }
+
+      if ($(".hale-header__mobile-controls--search").is(":visible")) {
+        $('.govuk-exit-this-page a').css({
+          "left": 0
+        });
+      }
+    }
+  });
+
+});

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -583,6 +583,38 @@ html.hale-colours-variable {
 		}
 	}
 
+	.govuk-exit-this-page .govuk-button{
+		border:var(--quick-exit-button-border);
+		box-shadow: none;
+		color:var(--quick-exit-button-text);
+		background-color:var(--quick-exit-button);
+		&:hover {
+			background-color: var(--quick-exit-button-hover);
+			color: var(--quick-exit-button-hover-text);
+			box-shadow: none;
+			border-color: var(--quick-exit-button-hover-border);
+			svg {
+				fill: var(--quick-exit-button-hover-text);
+			}
+		}
+		&:focus {
+			background-color: var(--quick-exit-button-focus);
+			color: var(--quick-exit-button-focus-text);
+			border-color: var(--quick-exit-button-focus-outline);
+			box-shadow: 0 0 0 3px var(--quick-exit-button-focus-outline);
+		}
+		&:focus:not(:active):not(:hover) {
+			background-color: var(--quick-exit-button-focus);
+			color: var(--quick-exit-button-focus-text);
+			border-color: var(--quick-exit-button-focus-outline);
+			box-shadow: 0 0 0 3px var(--quick-exit-button-focus-outline);
+		}
+		svg {
+			fill: var(--quick-exit-button-text);
+		}
+
+	}
+
 	.govuk-select,
 	.govuk-input {
 		border: 2px solid var(--input-border);

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -162,6 +162,39 @@
       margin-left: auto;
     }
   }
+  .govuk-exit-this-page {
+    min-height: 34px;
+    min-width: 130px;
+    margin-bottom: 0px;
+    width: 100%;
+
+    .govuk-button {
+      border-radius: 5px;
+      width: 100%;
+
+      @include govuk-media-query($from: desktop) {
+        width: auto;
+      }
+    }
+
+    @include govuk-media-query($from: desktop) {
+      width: auto;
+    }
+
+    &.sticky {
+      .govuk-button {
+        position: fixed;
+        top: 0;
+        left: 0;
+        border-radius: 0;
+
+        @include govuk-media-query($from: desktop) {
+          left: auto;
+          border-radius: 5px;
+        }
+      }
+    }
+  }
 }
 
 /*

--- a/header.php
+++ b/header.php
@@ -42,9 +42,18 @@ if ( ! function_exists( 'wp_body_open' ) ) {
 	}
 }
 wp_body_open();
+
+$header_quick_exit = get_theme_mod( 'show_quick_exit', 'no' );
 ?>
 <?php do_action( 'hale_after_body' ); ?>
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#content"><?php esc_html_e( 'Skip to content', 'hale' ); ?></a>
+<?php
+  if ( 'yes' === $header_quick_exit) {
+    ?>
+<a href="https://bbc.co.uk/weather/" class="govuk-skip-link govuk-js-exit-this-page-skiplink" rel="nofollow noreferrer" data-module="govuk-skip-link"><?php esc_html_e( 'Exit this page', 'hale' ); ?></a>
+<?php
+  }
+    ?>
 <?php
 include "inc/emergency-banner.php";
 ?>
@@ -73,7 +82,19 @@ echo '<header class="govuk-header hale-header ' . esc_attr( $header_search_class
     </div>
     <?php
   }
-?>     <?php
+?>
+  <?php
+  if ( 'yes' === $header_quick_exit) {
+    ?>
+	<div class="govuk-exit-this-page" data-module="govuk-exit-this-page">
+	<a href="https://www.bbc.co.uk/weather" role="button" draggable="false" class="govuk-button govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button" data-module="govuk-button" rel="nofollow noreferrer">
+		<span class="govuk-visually-hidden"><?php esc_html_e( 'Emergency', 'hale' ); ?></span> <?php esc_html_e( 'Exit this page', 'hale' ); ?>
+	</a>
+	</div>
+    <?php
+  }
+?>
+	<?php
         if ( 'no' === $header_search ) {
           $headersearchextra = 'hale-header__menu--only';
         } else {

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -111,6 +111,17 @@
 			['button-focus-text',$black,'Button text when focused','',''],
 			['button-focus-outline',$yellow,'Button outline when focused (including search button)','This is thicker than any set button border',''],
 
+			//Quick Exit button
+			['quick-exit-button',$green,'Quick Exit Button background','',''],
+			['quick-exit-button-text',$white,'Quick Exit Button text','',''],
+			['quick-exit-button-border',"none",'Quick Exit Button border','Enter a complete CSS value for border, e.g. "solid 2px #0b0c0c", "none"','text'], // not a colour
+			['quick-exit-button-hover',$buttonHoverGreen,'Quick Exit Button background on hover','',''],
+			['quick-exit-button-hover-text',$white,'Quick Exit Button text on hover','',''],
+			['quick-exit-button-hover-border','transparent','Quick Exit Button border on hover','Leave blank for none. Requires there to be a button border set',''],
+			['quick-exit-button-focus',$yellow,'Quick Exit Button background when focused','',''],
+			['quick-exit-button-focus-text',$black,'Quick Exit Button text when focused','',''],
+			['quick-exit-button-focus-outline',$yellow,'Quick Exit Button outline when focused (including search button)','This is thicker than any set button border',''],
+
 			//accordion - MoJ Blocks
 			['mojblocks-accordion-section-title',$black,'Accordion section titles','',''],
 			['mojblocks-accordion-section-shew',$blue,'Accordion show/hide','',''],

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -130,6 +130,32 @@ function hale_customize_register( $wp_customize ) {
         )
     );
 
+	/*
+	 * -----------------------------------------------------------
+	 * SHOW / HIDE Quick Exit Button
+	 * -----------------------------------------------------------
+	 */
+	$wp_customize->add_setting(
+		'show_quick_exit',
+		array(
+			'default'           => 'no',
+			'sanitize_callback' => 'hale_sanitize_select',
+		)
+	);
+	$wp_customize->add_control(
+		'show_quick_exit',
+		array(
+			'label'       => esc_html__( 'Show Quick Exit Button?', 'hale' ),
+			'description' => esc_html__( 'Would you like to quick exit button in the header?', 'hale' ),
+			'section'     => 'section_header',
+			'type'        => 'radio',
+			'choices'     => array(
+				'yes' => esc_html__( 'Yes', 'hale' ),
+				'no'  => esc_html__( 'No', 'hale' ),
+			),
+		)
+	);
+
     /*
         Show/Hide Site Name or Logo
     */

--- a/package-lock.json
+++ b/package-lock.json
@@ -4917,9 +4917,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true,
       "funding": [
         {

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -9,7 +9,8 @@ mix_.setPublicPath('./dist')
   .sass('./assets/scss/page-colours.scss', 'css/page-colours.min.css')
   .sass('./assets/scss/custom-branding.scss', 'css/custom-branding.min.css')
   .copy('./assets/js/*', 'dist/js/')
-  .copy('./node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js', 'dist/js/govuk-frontend.js')
+  //.copy('./node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js', 'dist/js/govuk-frontend.js')
+  .scripts(['./node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js', './assets/js/gov-overrides.js'], 'dist/js/govuk-frontend.js')
   .options({
     processCssUrls: false
   });


### PR DESCRIPTION
- The GOVUK Frontend JS is overridden so the ExitPage function opens in the new tab and clears the back button
- Adds new colour options for quick exit button
- Adds option in customiser to turn quick exit button on or off (default off)
- Uses JS to be sticky to top of page on scroll