### PR TITLE
Changed colour input back to text from colour picker

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -513,7 +513,9 @@ function hale_customize_register( $wp_customize ) {
 					'label' => esc_html__($colour_desig, 'hale'),
 					'description' => esc_html__($colour_hint, 'hale'),
 					'section' => 'colors',
-					'type' => $colour_options == "text" ? 'text' : 'color',
+					// If colour picker needed change to below 
+					// 'type' => $colour_options == "text" ? 'text' : 'color',
+					'type' => 'text',
 					'active_callback' => $show_colours,
 				)
 			);

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.1.1
+Version: 4.1.2
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Revert to a text entry for colours in customizer.  
Note added to aid changing back to a colour picker should this be needed.

NB: 

If doing bulk-entry and many changes, text entry is far easier to work with.
If reviewing current colours, the colour-picker preview is far more useful.  
Therefore we might need to change this back as per the main needs of the task/individual dealing with it.