### PR TITLE
Add Fix for admin menu

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -261,3 +261,15 @@ svg.hale-icon__search {
     min-height: 15px;
   }
 }
+
+body.admin-bar {
+
+  .govuk-exit-this-page.sticky {
+    .govuk-button {
+
+      @include govuk-media-query($from: desktop) {
+        top: 32px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Moves the  quick exit button further down if the admin menu is active