### PR TITLE
GDS Design System upgrade to v5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^5.0.0",
+        "govuk-frontend": "^5.2.0",
         "grunt": "^1.4.1",
         "nunjucks": "^3.2.3"
       },
@@ -5215,9 +5215,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^5.0.0",
+    "govuk-frontend": "^5.2.0",
     "grunt": "^1.4.1",
     "nunjucks": "^3.2.3"
   },


### PR DESCRIPTION
Upgrades to the latest GDS design system.  
No real impact for the Hale theme.
Font sizes have changed - but we override these styles with our own.
New crown has finally been introduced (only 5 months after we were told to use it), but we have already made this change where needed - and our own local code overrides this. 