### PR TITLE
Heading sizes

### DIFF
--- a/assets/scss/brandings-extended-core-blocks.scss
+++ b/assets/scss/brandings-extended-core-blocks.scss
@@ -1,4 +1,4 @@
-html.hale-colours-variable {
+body.hale-colours-variable {
 	//Group Block
 	.wp-block-group:not(.has-background) {
 		&.is-style-bleeding-background,

--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -1,6 +1,6 @@
 //brandings for MoJ Blocks
 
-html.hale-colours-variable {
+body.hale-colours-variable {
 	//Accordion block
 	.govuk-accordion,
 	.js-enabled .govuk-accordion {

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -691,7 +691,7 @@
 /***
 * These styles are only applied to sites which have not opted for GDS styles
 */
-html.hale-colours-variable {
+body.hale-colours-variable {
 
 	.govuk-skip-link:focus {
 		outline-color: var(--header-link-focus-underline);

--- a/assets/scss/decisions.scss
+++ b/assets/scss/decisions.scss
@@ -3,7 +3,7 @@
 }
 
 .decision-details {
-    @include govuk-font(19);
+    @include govuk-font-size($size: 19);
     font-weight: bold;
 
     .decision-published-date {
@@ -91,7 +91,7 @@
     padding-bottom: 16px;
     padding-top: 10px;
     text-align: right;
-    @include govuk-font(19);
+    @include govuk-font-size($size: 19);
 }
 
 .decision-list {
@@ -99,7 +99,7 @@
         border-bottom: 1px solid $govuk-border-colour;
 
         .decision-published-date {
-            @include govuk-font(19);
+            @include govuk-font-size($size: 19);
             margin-bottom: 20px;
             font-weight: bold;
 

--- a/assets/scss/default.scss
+++ b/assets/scss/default.scss
@@ -28,16 +28,6 @@ body {
   word-break: break-word;
 }
 
-/**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-
 /* Grouping content
 	 ========================================================================== */
 

--- a/assets/scss/documents.scss
+++ b/assets/scss/documents.scss
@@ -3,7 +3,7 @@
 }
 
 .document-details {
-  @include govuk-font(19);
+  @include govuk-font-size($size: 19);
   font-weight: bold;
 
   .document-published-date {
@@ -85,7 +85,7 @@
   padding-bottom: 16px;
   padding-top: 10px;
   text-align: right;
-  @include govuk-font(19);
+  @include govuk-font-size($size: 19);
 }
 
 .document-list {
@@ -93,7 +93,7 @@
     border-bottom: 1px solid $govuk-border-colour;
 
     .document-published-date {
-      @include govuk-font(19);
+      @include govuk-font-size($size: 19);
       margin-bottom: 20px;
       font-weight: bold;
 

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -3,6 +3,9 @@
  * Therefore all styles should be a child of class .edit-post-layout
 */
 
+@import 'style';
+
+
 .edit-post-visual-editor {
 	.editor-styles-wrapper {
 		margin: 0 2rem;

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -3,9 +3,6 @@
  * Therefore all styles should be a child of class .edit-post-layout
 */
 
-@import 'style';
-
-
 .edit-post-visual-editor {
 	.editor-styles-wrapper {
 		margin: 0 2rem;

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -3,6 +3,8 @@
  * Therefore all styles should be a child of class .edit-post-layout
 */
 
+@import 'fontstyles/pt-sans';
+
 .edit-post-visual-editor {
 	.editor-styles-wrapper {
 		margin: 0 2rem;

--- a/assets/scss/flexible-post-types.scss
+++ b/assets/scss/flexible-post-types.scss
@@ -8,7 +8,7 @@
       }
 
       .flexible-post-type-details {
-        @include govuk-font(19);
+        @include govuk-font-size($size: 19);
         font-weight: bold;
 
         .flexible-post-type-published-date {

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -17,18 +17,21 @@
 
   //Normally used for H1
   h1:not([class]),
+  h1.wp-block-heading,
   .hale-heading-xl {
     @extend .govuk-heading-xl;
   }
 
   //Normally used for H2
   h2:not([class]),
+  h2.wp-block-heading,
   .hale-heading-l {
     @extend .govuk-heading-l;
   }
 
   //Normally used for H3
   h3:not([class]),
+  h3.wp-block-heading,
   .hale-heading-m {
     @extend .govuk-heading-m;
   }
@@ -37,32 +40,44 @@
   h4:not([class]),
   h5:not([class]),
   h6:not([class]),
+  h4.wp-block-heading,
+  h5.wp-block-heading,
+  h6.wp-block-heading,
   .hale-heading-s {
     @extend .govuk-heading-s;
   }
 
-  .has-huge-font-size {
-    @include govuk-font-size($size: 48);
+  h1,h2,h3,h4 {
+    &.has-huge-font-size {
+      @include govuk-font-size($size: 48);
+    }
+    &.has-large-font-size {
+      @include govuk-font-size($size: 36);
+    }
+    &.has-medium-font-size {
+      @include govuk-font-size($size: 24);
+    }
+    &.has-small-font-size {
+      @include govuk-font-size($size: 19);
+    }
   }
 
-  .has-large-font-size {
+  .has-huge-font-size {
     @include govuk-font-size($size: 36);
   }
-
-  .has-medium-font-size {
+  .has-large-font-size {
     @include govuk-font-size($size: 24);
   }
-
-  .has-small-font-size {
+  .has-medium-font-size {
     @include govuk-font-size($size: 19);
   }
-
-
+  .has-small-font-size {
+    @include govuk-font-size($size: 16);
+  }
 
   p:not([class|="govuk"]) {
     @include govuk-font-size($size: 19);
   }
-
 
   .mojblocks-hero {
      h1 {

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -9,51 +9,34 @@
   Setting font-size:var(--gds-font-size-48) and line-height:var(--gds-line-height-48) is the same as @include govuk-font-size($size: 48);
 */
 
-:root {
-  // Mobile sizes
-  --gds-font-size-80: 53px; //exceptional use only
-  --gds-font-size-48: 32px;
-  --gds-font-size-36: 27px;
-  --gds-font-size-27: 21px; //exceptional use only - might become depricated soon
-  --gds-font-size-24: 21px;
-  --gds-font-size-19: 19px;
-  --gds-font-size-16: 16px;
-  --gds-line-height-80: 55px; //exceptional use only
-  --gds-line-height-48: 35px;
-  --gds-line-height-36: 30px;
-  --gds-line-height-27: 25px; //exceptional use only - might become depricated soon
-  --gds-line-height-24: 25px;
-  --gds-line-height-19: 25px;
-  --gds-line-height-16: 20px;
-  @include govuk-media-query($from: tablet) {
-    --gds-font-size-80: 80px; //exceptional use only
-    --gds-font-size-48: 48px;
-    --gds-font-size-36: 36px;
-    --gds-font-size-27: 27px; //exceptional use only - might become depricated soon
-    --gds-font-size-24: 24px;
-    --gds-line-height-80: 80px; //exceptional use only
-    --gds-line-height-48: 50px;
-    --gds-line-height-36: 40px;
-    --gds-line-height-27: 30px; //exceptional use only - might become depricated soon
-    --gds-line-height-24: 30px;
-  }
-  @include govuk-media-query($media-type: print) {
-    --gds-font-size-80: 53pt; //exceptional use only
-    --gds-font-size-48: 32pt;
-    --gds-font-size-36: 24pt;
-    --gds-font-size-27: 18pt; //exceptional use only - might become depricated soon
-    --gds-font-size-24: 18pt;
-    --gds-font-size-19: 14pt;
-    --gds-font-size-16: 14pt;
-    --gds-line-height-80: 1.1; //exceptional use only
-    --gds-line-height-48: 1.15;
-    --gds-line-height-36: 1.05;
-    --gds-line-height-27: 1.15; //exceptional use only - might become depricated soon
-    --gds-line-height-24: 1.15;
-    --gds-line-height-19: 1.15;
-    --gds-line-height-16: 1.2;
+@mixin hale-font-value() {
+  $sizes: 16, 19, 24, 36, 48; // These must be GDS sizes
+  :root {
+    @each $size in $sizes {
+      $font-map: map-get($_govuk-typography-scale-modern, $size);
+      @each $breakpoint, $breakpoint-map in $font-map {
+        $font-size: map-get($breakpoint-map, "font-size");
+        $line-height: map-get($breakpoint-map, "line-height");
+        @if not $breakpoint {
+          --gds-font-size-#{$size}: #{$font-size};
+          --gds-line-height-#{$size}: #{$line-height};
+        } @else if $breakpoint == "print" {
+          @include govuk-media-query($media-type: print) {
+            --gds-font-size-#{$size}: #{$font-size};
+            --gds-line-height-#{$size}: #{$line-height};
+          }
+        } @else {
+          @include govuk-media-query($from: tablet) {
+            --gds-font-size-#{$size}: #{$font-size};
+            --gds-line-height-#{$size}: #{$line-height};
+          }
+        }
+      }
+    }
   }
 }
+
+@include hale-font-value();
 
 //Normally used for display/hero
 #primary {

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -56,35 +56,20 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: antialiased;
 }
-.hale-heading-xxl {
-  // I don't think this is used, but included just in case
-  @include govuk-font-size($size: 80);
-}
 
-//Normally used for H1
 h1,
-.hale-heading-xl {
-  @extend .govuk-heading-xl;
-}
-
-//Normally used for H2
-h2,
-.hale-heading-l,
 .mojblocks-hero h1 {
   @extend .govuk-heading-l;
 }
 
-//Normally used for H3
-h3,
-.hale-heading-m {
+h2 {
   @extend .govuk-heading-m;
 }
 
-//Normally used for H4
+h3,
 h4,
 h5,
-h6,
-.hale-heading-s {
+h6 {
   @extend .govuk-heading-s;
 }
 

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -10,6 +10,7 @@
 */
 
 :root {
+  // Mobile sizes
   --gds-font-size-80: 53px; //exceptional use only
   --gds-font-size-48: 32px;
   --gds-font-size-36: 27px;

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -83,7 +83,7 @@ h1,h2,h3,h4 {
 .has-huge-font-size {
   @include govuk-font-size($size: 36);
 }
-.intro, .intro p,
+#primary .intro, #primary .intro p,
 .has-large-font-size {
   @include govuk-font-size($size: 24);
 }

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -16,95 +16,61 @@
   }
 
   //Normally used for H1
+  h1:not([class]),
   .hale-heading-xl {
-    font-size: 50px;
-    font-size: 3.125rem;
-    line-height: 120%;
-
-    @include govuk-media-query($from: tablet) {
-      font-size: 56px;
-      font-size: 3.5rem;
-    }
+    @extend .govuk-heading-xl;
   }
 
   //Normally used for H2
+  h2:not([class]),
   .hale-heading-l {
-    font-size: 38px;
-    font-size: 2.375rem;
-    line-height: 120%;
-
-    @include govuk-media-query($from: tablet) {
-      font-size: 42px;
-      font-size: 2.625rem;
-    }
+    @extend .govuk-heading-l;
   }
 
   //Normally used for H3
+  h3:not([class]),
   .hale-heading-m {
-    font-size: 28px;
-    font-size: 1.75rem;
-    line-height: 130%;
-
-    @include govuk-media-query($from: tablet) {
-      font-size: 32px;
-      font-size: 2.0rem;
-    }
+    @extend .govuk-heading-m;
   }
 
   //Normally used for H4
+  h4:not([class]),
+  h5:not([class]),
+  h6:not([class]),
   .hale-heading-s {
-    @include govuk-font(24);
-    font-weight:700;
+    @extend .govuk-heading-s;
   }
 
-  // only classless
-  h1:not([class]) {
-    @extend .hale-heading-xl;
+  .has-huge-font-size {
+    @include govuk-font-size($size: 48);
   }
 
-  h2:not([class]) {
-    @extend .hale-heading-l;
+  .has-large-font-size {
+    @include govuk-font-size($size: 36);
   }
 
-  h3:not([class]) {
-    @extend .hale-heading-m;
+  .has-medium-font-size {
+    @include govuk-font-size($size: 24);
   }
 
-  h4:not([class]) {
-    @extend .hale-heading-s;
+  .has-small-font-size {
+    @include govuk-font-size($size: 19);
   }
 
-  h1,h2,h3,h4 {
-    &.has-huge-font-size {
-      @extend .hale-heading-xl;
-    }
-
-    &.has-large-font-size {
-      @extend .hale-heading-l;
-    }
-
-    &.has-medium-font-size {
-      @extend .hale-heading-m;
-    }
-
-    &.has-small-font-size {
-      @extend .hale-heading-s;
-    }
-  }
 
 
   p:not([class|="govuk"]) {
-    @include govuk-font(19);
+    @include govuk-font-size($size: 19);
   }
 
 
   .mojblocks-hero {
      h1 {
-       @extend .hale-heading-l;
+       @extend .govuk-heading-l;
      }
   }
 
   .intro, .intro p {
-    @include govuk-font(24);
+    @include govuk-font-size($size: 24);
   }
 }

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -1,7 +1,12 @@
 /*
   The following are copied from $_govuk-typography-scale-modern from the design system.
   We use variables here as we need to set the WordPress variable to the size to prevent Gutenberg overriding it.
-  We have omitted the 14px size - depricated by GDS and we don't need it.
+  We have omitted the 14px size - depricated by GDS and we don't need it, the GDS mixin will stop supporting this after v6.
+  We have kept the 27px size - probably will soon be depricated by GDS as the sizes on mobile and printing are the same.
+  We have kept the 80px size - but we probably don't need it.
+
+  Elsewhere, we use the GDS mixin.
+  Setting font-size:var(--gds-font-size-48) and line-height:var(--gds-line-height-48) is the same as @include govuk-font-size($size: 48);
 */
 
 :root {
@@ -46,19 +51,16 @@
     --gds-line-height-24: 1.15;
     --gds-line-height-19: 1.15;
     --gds-line-height-16: 1.2;
-    }
+  }
 }
-
 
 //Normally used for display/hero
 #primary {
-
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: antialiased;
 }
 
-h1,
-.mojblocks-hero h1 {
+h1 {
   @extend .govuk-heading-l;
 }
 
@@ -73,7 +75,11 @@ h6 {
   @extend .govuk-heading-s;
 }
 
-
+/*
+  The GDS mixin govuk-font-size brings in line-height and font-size
+  Note that headings are one size notch higher than everyone else!
+  Also note that these are set in themes.json as well ∵ inbuilt WP variable looks there
+*/
 
 h1,h2,h3,h4 {
   &.has-huge-font-size {

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -5,14 +5,8 @@
   -moz-osx-font-smoothing: antialiased;
   
   .hale-heading-xxl {
-    font-size: 68px;
-    font-size: 4.25rem;
-    line-height: 120%;
-
-    @include govuk-media-query($from: tablet) {
-      font-size: 76px;
-      font-size: 4.75rem;
-    }
+    // I don't think this is used, but included just in case
+    @include govuk-font-size($size: 80);
   }
 
   //Normally used for H1

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -1,85 +1,121 @@
+/*
+  The following are copied from $_govuk-typography-scale-modern from the design system.
+  We use variables here as we need to set the WordPress variable to the size to prevent Gutenberg overriding it.
+  We have omitted the 14px size - depricated by GDS and we don't need it.
+*/
+
+:root {
+  --gds-font-size-80: 53px; //exceptional use only
+  --gds-font-size-48: 32px;
+  --gds-font-size-36: 27px;
+  --gds-font-size-27: 21px; //exceptional use only - might become depricated soon
+  --gds-font-size-24: 21px;
+  --gds-font-size-19: 19px;
+  --gds-font-size-16: 16px;
+  --gds-line-height-80: 55px; //exceptional use only
+  --gds-line-height-48: 35px;
+  --gds-line-height-36: 30px;
+  --gds-line-height-27: 25px; //exceptional use only - might become depricated soon
+  --gds-line-height-24: 25px;
+  --gds-line-height-19: 25px;
+  --gds-line-height-16: 20px;
+  @include govuk-media-query($from: tablet) {
+    --gds-font-size-80: 80px; //exceptional use only
+    --gds-font-size-48: 48px;
+    --gds-font-size-36: 36px;
+    --gds-font-size-27: 27px; //exceptional use only - might become depricated soon
+    --gds-font-size-24: 24px;
+    --gds-line-height-80: 80px; //exceptional use only
+    --gds-line-height-48: 50px;
+    --gds-line-height-36: 40px;
+    --gds-line-height-27: 30px; //exceptional use only - might become depricated soon
+    --gds-line-height-24: 30px;
+  }
+  @include govuk-media-query($media-type: print) {
+    --gds-font-size-80: 53pt; //exceptional use only
+    --gds-font-size-48: 32pt;
+    --gds-font-size-36: 24pt;
+    --gds-font-size-27: 18pt; //exceptional use only - might become depricated soon
+    --gds-font-size-24: 18pt;
+    --gds-font-size-19: 14pt;
+    --gds-font-size-16: 14pt;
+    --gds-line-height-80: 1.1; //exceptional use only
+    --gds-line-height-48: 1.15;
+    --gds-line-height-36: 1.05;
+    --gds-line-height-27: 1.15; //exceptional use only - might become depricated soon
+    --gds-line-height-24: 1.15;
+    --gds-line-height-19: 1.15;
+    --gds-line-height-16: 1.2;
+    }
+}
+
+
 //Normally used for display/hero
 #primary {
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: antialiased;
-  
-  .hale-heading-xxl {
-    // I don't think this is used, but included just in case
-    @include govuk-font-size($size: 80);
-  }
+}
+.hale-heading-xxl {
+  // I don't think this is used, but included just in case
+  @include govuk-font-size($size: 80);
+}
 
-  //Normally used for H1
-  h1:not([class]),
-  h1.wp-block-heading,
-  .hale-heading-xl {
-    @extend .govuk-heading-xl;
-  }
+//Normally used for H1
+h1,
+.hale-heading-xl {
+  @extend .govuk-heading-xl;
+}
 
-  //Normally used for H2
-  h2:not([class]),
-  h2.wp-block-heading,
-  .hale-heading-l {
-    @extend .govuk-heading-l;
-  }
+//Normally used for H2
+h2,
+.hale-heading-l,
+.mojblocks-hero h1 {
+  @extend .govuk-heading-l;
+}
 
-  //Normally used for H3
-  h3:not([class]),
-  h3.wp-block-heading,
-  .hale-heading-m {
-    @extend .govuk-heading-m;
-  }
+//Normally used for H3
+h3,
+.hale-heading-m {
+  @extend .govuk-heading-m;
+}
 
-  //Normally used for H4
-  h4:not([class]),
-  h5:not([class]),
-  h6:not([class]),
-  h4.wp-block-heading,
-  h5.wp-block-heading,
-  h6.wp-block-heading,
-  .hale-heading-s {
-    @extend .govuk-heading-s;
-  }
+//Normally used for H4
+h4,
+h5,
+h6,
+.hale-heading-s {
+  @extend .govuk-heading-s;
+}
 
-  h1,h2,h3,h4 {
-    &.has-huge-font-size {
-      @include govuk-font-size($size: 48);
-    }
-    &.has-large-font-size {
-      @include govuk-font-size($size: 36);
-    }
-    &.has-medium-font-size {
-      @include govuk-font-size($size: 24);
-    }
-    &.has-small-font-size {
-      @include govuk-font-size($size: 19);
-    }
-  }
 
-  .has-huge-font-size {
+
+h1,h2,h3,h4 {
+  &.has-huge-font-size {
+    @include govuk-font-size($size: 48);
+  }
+  &.has-large-font-size {
     @include govuk-font-size($size: 36);
   }
-  .has-large-font-size {
+  &.has-medium-font-size {
     @include govuk-font-size($size: 24);
   }
-  .has-medium-font-size {
+  &.has-small-font-size {
     @include govuk-font-size($size: 19);
   }
-  .has-small-font-size {
-    @include govuk-font-size($size: 16);
-  }
+}
 
-  p:not([class|="govuk"]) {
-    @include govuk-font-size($size: 19);
-  }
-
-  .mojblocks-hero {
-     h1 {
-       @extend .govuk-heading-l;
-     }
-  }
-
-  .intro, .intro p {
-    @include govuk-font-size($size: 24);
-  }
+.has-huge-font-size {
+  @include govuk-font-size($size: 36);
+}
+.intro, .intro p,
+.has-large-font-size {
+  @include govuk-font-size($size: 24);
+}
+p,
+.has-medium-font-size {
+  @include govuk-font-size($size: 19);
+}
+.has-small-font-size {
+  @include govuk-font-size($size: 16);
 }

--- a/assets/scss/listing.scss
+++ b/assets/scss/listing.scss
@@ -29,14 +29,14 @@
       padding-bottom: 16px;
       padding-top: 10px;
       text-align: right;
-      @include govuk-font(19);
+      @include govuk-font-size($size: 19);
     }
 
     .list-item {
       border-bottom: 1px solid $govuk-border-colour;
 
       .list-item-published-date {
-        @include govuk-font(19);
+        @include govuk-font-size($size: 19);
         margin-bottom: 20px;
         font-weight: bold;
 

--- a/assets/scss/news.scss
+++ b/assets/scss/news.scss
@@ -6,7 +6,7 @@
   }
 
   .news-story-details {
-    @include govuk-font(19);
+    @include govuk-font-size($size: 19);
     font-weight: bold;
   }
 
@@ -52,7 +52,7 @@
 .news-story-count {
   font-weight: bold;
   border-bottom: 1px solid $govuk-border-colour;
-  @include govuk-font(24);
+  @include govuk-font-size($size: 24);
   padding-bottom: 16px;
 }
 

--- a/assets/scss/pagination.scss
+++ b/assets/scss/pagination.scss
@@ -42,7 +42,7 @@
 }
 
 .moj-pagination__results {
-  @include govuk-font(19);
+  @include govuk-font-size($size: 19);
   margin-top: 0;
   @include govuk-media-query($from: desktop) {
     display: inline-block;
@@ -52,7 +52,7 @@
 }
 
 .moj-pagination__item {
-  @include govuk-font(19);
+  @include govuk-font-size($size: 19);
   display: inline-block;
 }
 
@@ -133,7 +133,7 @@
 }
 
 .gem-c-pagination__item {
-  @include govuk-font($size: 16, $line-height: (20 / 16));
+  @include govuk-font-size($size: 16, $line-height: (20 / 16));
   list-style: none;
 
   &:first-child {
@@ -182,12 +182,12 @@
 }
 
 .gem-c-pagination__link-text {
-  @include govuk-font(19, $weight: bold);
+  @include govuk-font($size: 19, $weight: bold);
   margin-left: govuk-spacing(2);
 }
 
 .gem-c-pagination__link-icon {
-  @include govuk-font($size: 24, $line-height: (33.75 / 27));
+  @include govuk-font-size($size: 24, $line-height: (33.75 / 27));
   display: inline-block;
   margin-bottom: 1px;
   height: .482em;
@@ -217,7 +217,7 @@
       padding-left:30px;
 
       .gem-c-pagination__link-text {
-        @include govuk-font(24);
+        @include govuk-font-size($size: 24);
       }
     }
     .gem-c-pagination__link-label {

--- a/assets/scss/pagination.scss
+++ b/assets/scss/pagination.scss
@@ -182,7 +182,8 @@
 }
 
 .gem-c-pagination__link-text {
-  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-font-size($size: 19);
+  font-weight: $govuk-font-weight-bold;
   margin-left: govuk-spacing(2);
 }
 

--- a/assets/scss/secondary-top-nav.scss
+++ b/assets/scss/secondary-top-nav.scss
@@ -27,7 +27,7 @@
       color: govuk-colour("black");
       text-decoration: none;
 
-      @include govuk-font(19);
+      @include govuk-font-size($size: 19);
 
       &:hover {
         text-decoration: underline;

--- a/functions.php
+++ b/functions.php
@@ -162,37 +162,6 @@ function hale_setup()
 
 add_action('after_setup_theme', 'hale_setup');
 
-/* taken from https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-font-sizes */
-add_action('after_setup_theme', 'wpse_remove_custom_colors');
-function wpse_remove_custom_colors() {
-    // removes the text box where users can enter custom pixel sizes
-    add_theme_support('disable-custom-font-sizes');
-    // specifies the options (removed "normal")
-    add_theme_support('editor-font-sizes', array(
-        array(
-            'name' => 'Small',
-            'size' => '22',
-            'slug' => 'small'
-        ),
-        array(
-            'name' => 'Medium',
-            'size' => '28',
-            'slug' => 'medium'
-        ),
-        array(
-            'name' => 'Large',
-            'size' => '38',
-            'slug' => 'large'
-        ),
-        array(
-            'name' => 'Huge',
-            'size' => '50',
-            'slug' => 'huge'
-        )
-    ) );
-}
-
-
 /**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  * Priority 0 to make it available to lower priority callbacks.

--- a/header.php
+++ b/header.php
@@ -9,18 +9,9 @@
  * @version   1.0
  */
 
-	$custom_colours_set = ! get_theme_mod("gds_style_tickbox");
-	if (!$custom_colours_set) {
-		$style_class = "hale-colours-gds-standard";
-	} else {
-		$style_class = "hale-colours-variable";
-	}
-	if (is_front_page()) {
-		$style_class .= " hale-landing-page";
-	}
 ?>
 <!DOCTYPE html>
-<html <?php language_attributes(); ?> class="hale-page <?php printf($style_class); ?>">
+<html <?php language_attributes(); ?> class="hale-page">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta charset="<?php bloginfo( 'charset' ); ?>">

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -149,7 +149,19 @@ function hale_get_branding_class() {
 		hale_generate_custom_colours();
 	}
 
-	return "hale-site-" . get_current_blog_id();
+	$style_class = "hale-site-" . get_current_blog_id();
+
+	$custom_colours_set = ! get_theme_mod("gds_style_tickbox");
+	if (!$custom_colours_set) {
+		$style_class = " hale-colours-gds-standard";
+	} else {
+		$style_class = " hale-colours-variable";
+	}
+	if (is_front_page()) {
+		$style_class .= " hale-landing-page";
+	}
+
+	return $style_class;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^5.0.0",
+        "govuk-frontend": "^5.2.0",
         "grunt": "^1.4.1",
         "nunjucks": "^3.2.3"
       },
@@ -5215,9 +5215,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^5.0.0",
+    "govuk-frontend": "^5.2.0",
     "grunt": "^1.4.1",
     "nunjucks": "^3.2.3"
   },

--- a/page-full-width.php
+++ b/page-full-width.php
@@ -45,7 +45,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-xl"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-xl govuk-!-static-margin-bottom-6"><?php the_title(); ?></h1>
              <?php
                 }
 

--- a/page-full-width.php
+++ b/page-full-width.php
@@ -45,7 +45,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-l"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-xl"><?php the_title(); ?></h1>
              <?php
                 }
 

--- a/page-full-width.php
+++ b/page-full-width.php
@@ -45,7 +45,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-l hale-heading-xl"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-l"><?php the_title(); ?></h1>
              <?php
                 }
 
@@ -61,7 +61,7 @@ while (have_posts()) :
             if (!empty($is_cat_page)) {
 
             // Add special heading CSS class depending on if category menu is activated
-            $hale_heading_class = $is_cat_page ? ' hale-heading-l' : null;
+            $hale_heading_class = $is_cat_page ? ' govuk-heading-l' : '';
 
                 echo '<h1 class="entry-title' . $hale_heading_class . '">' . get_the_title() . '</h1>';
             }

--- a/page-job-listing.php
+++ b/page-job-listing.php
@@ -136,7 +136,7 @@ while (have_posts()) :
                 </div>
             </div>
         <?php } ?>
-        <h1 class="govuk-heading-xl">
+        <h1 class="govuk-heading-xl govuk-!-static-margin-0">
             <?php echo get_the_title(); ?>
         </h1>
 

--- a/page-listing.php
+++ b/page-listing.php
@@ -31,7 +31,7 @@ while (have_posts()) :
     ?>
 
     <div id="primary" class="govuk-grid-column-full-from-desktop">
-        <h1 class="govuk-heading-xl">
+        <h1 class="govuk-heading-xl govuk-!-static-margin-bottom-6">
             <?php echo get_the_title(); ?>
         </h1>
 

--- a/page.php
+++ b/page.php
@@ -52,7 +52,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-l"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-xl"><?php the_title(); ?></h1>
              <?php
                 }
 

--- a/page.php
+++ b/page.php
@@ -52,7 +52,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-xl"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-xl govuk-!-static-margin-bottom-6"><?php the_title(); ?></h1>
              <?php
                 }
 

--- a/page.php
+++ b/page.php
@@ -52,7 +52,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-l hale-heading-xl"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-l"><?php the_title(); ?></h1>
              <?php
                 }
 
@@ -70,7 +70,7 @@ while (have_posts()) :
             if (!empty($is_cat_page)) {
 
             // Add special heading CSS class depending on if category menu is activated
-            $hale_heading_class = $is_cat_page ? ' hale-heading-l' : null;
+            $hale_heading_class = $is_cat_page ? ' govuk-heading-l' : '';
 
                 echo '<h1 class="entry-title' . $hale_heading_class . '">' . get_the_title() . '</h1>';
             }

--- a/partials/category-list-section.php
+++ b/partials/category-list-section.php
@@ -39,7 +39,7 @@ if (!empty($page_cats)) {
 
             $is_cat_page = true;
         ?>
-        <h2 class="govuk-heading-l hale-heading-xl hale-heading--top"><?php echo $page_cat->name; ?></h2>
+        <h2 class="govuk-heading-xl"><?php echo $page_cat->name; ?></h2>
         <ul class="govuk-list govuk-list--bullet hale-list--top">
             <?php
             foreach ($pages as $key => $post) : ?>

--- a/search.php
+++ b/search.php
@@ -17,8 +17,8 @@ get_header();
 
 	<div id="primary" class="govuk-grid-column-two-thirds">
 		<header class="hale-search-header" style="">
-      <h1 class="govuk-heading-l hale-heading-xl" style="line-height:0;">
-        <span class="govuk-heading-l hale-heading-xl govuk-!-margin-bottom-0">
+      <h1 style="line-height:0;">
+        <span class="govuk-heading-xl govuk-!-margin-bottom-0">
           <?php _e("Search Results","hale");?>
         </span>
         <br />

--- a/template-parts/content-decisions.php
+++ b/template-parts/content-decisions.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="decision-list-item">
-    <h2 class="decision-list-item-title hale-heading-s"><a
+    <h2 class="decision-list-item-title govuk-heading-m"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="decision-excerpt"></div>
 </div>

--- a/template-parts/content-document-list-item.php
+++ b/template-parts/content-document-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="document-list-item">
-    <h2 class="document-list-item-title hale-heading-s"><a
+    <h2 class="document-list-item-title govuk-heading-m"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="document-published-date">
         Published: <?php hale_posted_on(); ?>

--- a/template-parts/content-news-list-item.php
+++ b/template-parts/content-news-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="news-story-list-item">
-    <h2 class="news-story-list-item-title hale-heading-s"><a
+    <h2 class="news-story-list-item-title govuk-heading-m"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="news-story-published-date">
         Published: <?php hale_posted_on(); ?>

--- a/template-parts/flexible-cpts/list-item.php
+++ b/template-parts/flexible-cpts/list-item.php
@@ -8,7 +8,7 @@
 
 
 <div class="list-item type-<?php echo  $flex_cpt_settings['post_type_object_type'] ?>">
-    <h2 class="list-item-title hale-heading-s">
+    <h2 class="list-item-title govuk-heading-m">
         <?php if($flex_cpt_settings['post_type_single_view'] !== false){ ?>
             <a href="<?php echo get_permalink(); ?>">
                 <?php echo get_the_title(); ?>

--- a/template-parts/flexible-cpts/type-document-list-item.php
+++ b/template-parts/flexible-cpts/type-document-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="list-item type-document">
-    <h2 class="list-item-title hale-heading-s"><a
+    <h2 class="list-item-title govuk-heading-m"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="list-item-published-date">
         Published: <?php hale_posted_on(); ?>

--- a/template-parts/flexible-cpts/type-news-list-item.php
+++ b/template-parts/flexible-cpts/type-news-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="list-item type-news">
-    <h2 class="list-item-title hale-heading-s"><a
+    <h2 class="list-item-title govuk-heading-m"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="list-item-published-date">
         Published: <?php hale_posted_on(); ?>

--- a/template-parts/flexible-cpts/type-simple-list-item.php
+++ b/template-parts/flexible-cpts/type-simple-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="list-item type-simple">
-    <h2 class="list-item-title hale-heading-s"><a
+    <h2 class="list-item-title govuk-heading-m"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="list-item-published-date">
         Published: <?php hale_posted_on(); ?>

--- a/theme.json
+++ b/theme.json
@@ -64,15 +64,81 @@
         ]
       },
       "typography": {
-        "textTransform": false
+        "textTransform": false,
+        "fontSizes": [
+          {
+            "slug": "small",
+            "size": "var(--gds-font-size-16)",
+            "name": "Small"
+          },
+          {
+            "slug": "medium",
+            "size": "var(--gds-font-size-19)",
+            "name": "Medium"
+          },
+          {
+            "slug": "large",
+            "size": "var(--gds-font-size-24)",
+            "name": "Large"
+          },
+          {
+            "slug": "huge",
+            "size": "var(--gds-font-size-36)",
+            "name": "Extra large"
+          }
+        ]
       },
       "blocks": {
+        "core/heading": {
+          "typography": {
+            "customFontSize": true,
+            "customLineHeight": false,
+            "fontSizes": [
+              {
+                "slug": "small",
+                "size": "var(--gds-font-size-19)",
+                "name": "Small"
+              },
+              {
+                "slug": "medium",
+                "size": "var(--gds-font-size-24)",
+                "name": "Medium"
+              },
+              {
+                "slug": "large",
+                "size": "var(--gds-font-size-36)",
+                "name": "Large"
+              },
+              {
+                "slug": "huge",
+                "size": "var(--gds-font-size-48)",
+                "name": "Extra large"
+              }
+            ]
+          }
+        },
         "core/paragraph": {
           "typography": {
             "customFontSize": true,
             "customLineHeight": false,
-            "dropCap": true,
-            "fontSizes": []
+            "dropCap": false,
+            "fontSizes": [
+              {
+                "slug": "small",
+                "size": "var(--gds-font-size-16)",
+                "name": "Small (default)"
+              },
+              {
+                "slug": "medium",
+                "size": "var(--gds-font-size-19)",
+                "name": "Medium"
+              },
+              {
+                "slug": "large",
+                "size": "var(--gds-font-size-24)",
+                "name": "Large"
+              }
+            ]
           }
         },
         "core/list": {

--- a/theme.json
+++ b/theme.json
@@ -116,6 +116,11 @@
           "typography": {
             "dropCap": false
           }
+        },
+        "core/list-item": {
+          "typography": {
+            "fontSizes": []
+          }
         }
       }
     }

--- a/theme.json
+++ b/theme.json
@@ -64,6 +64,8 @@
         ]
       },
       "typography": {
+        "customFontSize": false,
+        "customLineHeight": false,
         "textTransform": false,
         "fontSizes": [
           {
@@ -80,19 +82,12 @@
             "slug": "large",
             "size": "var(--gds-font-size-24)",
             "name": "Large"
-          },
-          {
-            "slug": "huge",
-            "size": "var(--gds-font-size-36)",
-            "name": "Extra large"
           }
         ]
       },
       "blocks": {
         "core/heading": {
           "typography": {
-            "customFontSize": true,
-            "customLineHeight": false,
             "fontSizes": [
               {
                 "slug": "small",
@@ -119,72 +114,7 @@
         },
         "core/paragraph": {
           "typography": {
-            "customFontSize": false,
-            "customLineHeight": false,
-            "dropCap": false,
-            "fontSizes": [
-              {
-                "slug": "small",
-                "size": "var(--gds-font-size-16)",
-                "name": "Small"
-              },
-              {
-                "slug": "medium",
-                "size": "var(--gds-font-size-19)",
-                "name": "Medium (default)"
-              },
-              {
-                "slug": "large",
-                "size": "var(--gds-font-size-24)",
-                "name": "Large"
-              }
-            ]
-          }
-        },
-        "core/list": {
-          "typography": {
-            "customFontSize": false,
-            "customLineHeight": false,
-            "fontSizes": [
-              {
-                "slug": "small",
-                "size": "var(--gds-font-size-16)",
-                "name": "Small"
-              },
-              {
-                "slug": "medium",
-                "size": "var(--gds-font-size-19)",
-                "name": "Medium (default)"
-              },
-              {
-                "slug": "large",
-                "size": "var(--gds-font-size-24)",
-                "name": "Large"
-              }
-            ]
-          }
-        },
-        "core/list-item": {
-          "typography": {
-            "customFontSize": false,
-            "customLineHeight": false,
-            "fontSizes": [
-              {
-                "slug": "small",
-                "size": "var(--gds-font-size-16)",
-                "name": "Small"
-              },
-              {
-                "slug": "medium",
-                "size": "var(--gds-font-size-19)",
-                "name": "Medium (default)"
-              },
-              {
-                "slug": "large",
-                "size": "var(--gds-font-size-24)",
-                "name": "Large"
-              }
-            ]
+            "dropCap": false
           }
         }
       }

--- a/theme.json
+++ b/theme.json
@@ -144,7 +144,47 @@
         "core/list": {
           "typography": {
             "customFontSize": true,
-            "fontSizes": []
+            "customLineHeight": false,
+            "fontSizes": [
+              {
+                "slug": "small",
+                "size": "var(--gds-font-size-16)",
+                "name": "Small (default)"
+              },
+              {
+                "slug": "medium",
+                "size": "var(--gds-font-size-19)",
+                "name": "Medium"
+              },
+              {
+                "slug": "large",
+                "size": "var(--gds-font-size-24)",
+                "name": "Large"
+              }
+            ]
+          }
+        },
+        "core/list-item": {
+          "typography": {
+            "customFontSize": true,
+            "customLineHeight": false,
+            "fontSizes": [
+              {
+                "slug": "small",
+                "size": "var(--gds-font-size-16)",
+                "name": "Small (default)"
+              },
+              {
+                "slug": "medium",
+                "size": "var(--gds-font-size-19)",
+                "name": "Medium"
+              },
+              {
+                "slug": "large",
+                "size": "var(--gds-font-size-24)",
+                "name": "Large"
+              }
+            ]
           }
         }
       }

--- a/theme.json
+++ b/theme.json
@@ -119,19 +119,19 @@
         },
         "core/paragraph": {
           "typography": {
-            "customFontSize": true,
+            "customFontSize": false,
             "customLineHeight": false,
             "dropCap": false,
             "fontSizes": [
               {
                 "slug": "small",
                 "size": "var(--gds-font-size-16)",
-                "name": "Small (default)"
+                "name": "Small"
               },
               {
                 "slug": "medium",
                 "size": "var(--gds-font-size-19)",
-                "name": "Medium"
+                "name": "Medium (default)"
               },
               {
                 "slug": "large",
@@ -143,18 +143,18 @@
         },
         "core/list": {
           "typography": {
-            "customFontSize": true,
+            "customFontSize": false,
             "customLineHeight": false,
             "fontSizes": [
               {
                 "slug": "small",
                 "size": "var(--gds-font-size-16)",
-                "name": "Small (default)"
+                "name": "Small"
               },
               {
                 "slug": "medium",
                 "size": "var(--gds-font-size-19)",
-                "name": "Medium"
+                "name": "Medium (default)"
               },
               {
                 "slug": "large",
@@ -166,18 +166,18 @@
         },
         "core/list-item": {
           "typography": {
-            "customFontSize": true,
+            "customFontSize": false,
             "customLineHeight": false,
             "fontSizes": [
               {
                 "slug": "small",
                 "size": "var(--gds-font-size-16)",
-                "name": "Small (default)"
+                "name": "Small"
               },
               {
                 "slug": "medium",
                 "size": "var(--gds-font-size-19)",
-                "name": "Medium"
+                "name": "Medium (default)"
               },
               {
                 "slug": "large",


### PR DESCRIPTION
- Moved to using GDS heading sizes and font sizes.
  - Removed the defunct `hale-heading-x` sizes.  
    - M and XXL were not used.  
    - S was already the same size as GDS M - so this replaces it.  
    - L was nearest to GDS L, XL was nearest to GDS XL so replaced like that.  
  - Made the `has-x-font-size` classes use GDS sizes.
    - New CSS variables to make this work within the existing WP methodology.
- Adopted the latest GDS mixins.
  - New mixins from GDS Design System v5.0.2, so this latest version has also been brought in in this PR.
- CSS rationalisation, reduce superfluous rules.
- Added font size options to list, list items and paragraphs to fix existing bug.
- Removed drop cap option from paragraph.