### PR TITLE
Added template class to editor and applied GDS width classes

### DIFF
--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -5,9 +5,25 @@
 
 @import 'fontstyles/pt-sans';
 
+.hale-template {
+	&--page-full-width {
+		.editor-styles-wrapper {
+			@extend .govuk-grid-column-full-from-desktop;
+		}
+	}
+	&--default {
+		.editor-styles-wrapper {
+			@extend .govuk-grid-column-two-thirds;
+		}
+	}
+}
+
 .edit-post-visual-editor {
+	@extend .govuk-width-container;
+
 	.editor-styles-wrapper {
-		margin: 0 2rem;
+		margin: 0 minmax(2rem, auto);
+		z-index: 0;
 	}
 
 	/**

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -87,7 +87,7 @@ h1,h2,h3,h4 {
 .has-large-font-size {
   @include govuk-font-size($size: 24);
 }
-p,
+p, ol, ul,
 .has-medium-font-size {
   @include govuk-font-size($size: 19);
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -168,15 +168,20 @@ function hale_get_branding_class() {
  * Get the template which has been selected for the page
  */
 function hale_get_template_class() {
-	$template = get_page_template_slug();
-	if ($template) {
-		$class = preg_replace('/\.php$/', "", $template);
-		$classes = " hale-template hale-template--" . sanitize_html_class($class);
-	} else {
-		// default template selected
-		$classes = " hale-template hale-template--default";
+	$screen = get_current_screen();
+	//Checks if on page edit screen
+	if ($screen->base === "post" && $screen->post_type === "page") {
+		$template = get_page_template_slug();
+		if ($template) {
+			$class = preg_replace('/\.php$/', "", $template);
+			$classes = " hale-template hale-template--" . sanitize_html_class($class);
+		} else {
+			// default template selected
+			$classes = " hale-template hale-template--default";
+		}
+		return $classes;
 	}
-	return $classes;
+	return;
 }
 add_filter( 'admin_body_class', 'hale_get_template_class' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -165,6 +165,23 @@ function hale_get_branding_class() {
 }
 
 /**
+ * Get the template which has been selected for the page
+ */
+function hale_get_template_class() {
+	$template = get_page_template_slug();
+	if ($template) {
+		$class = preg_replace('/\.php$/', "", $template);
+		$classes = " hale-template hale-template--" . sanitize_html_class($class);
+	} else {
+		// default template selected
+		$classes = " hale-template hale-template--default";
+	}
+	return $classes;
+}
+add_filter( 'admin_body_class', 'hale_get_template_class' );
+
+
+/**
  * Get the custom colour name to return into the body class if required
  *
  * @param array $classes the pre-existing classes for a WordPress page.
@@ -186,7 +203,7 @@ function hale_admin_custom_page_colour( $classes ) {
         return;
     }
 
-    $classes .= ' ' . hale_get_branding_class(); //none set = use Neptune
+    $classes .= ' ' . hale_get_branding_class();
 
     return $classes;
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.4.2
+Version: 4.4.3
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Applied the GDS widths to the editor screen by extending the GDS classes.  
- `govuk-grid-column-full-from-desktop` for full width
- `govuk-grid-column-two-thirds` for default

Added a new bit of PHP to add a class so the editor knows which template is being used.

Added lists to the font size declaration, so the editor has the same font size as the frontend for lists.  