### PR TITLE
News story title spacing and filter bug fix

### DIFF
--- a/assets/scss/decisions.scss
+++ b/assets/scss/decisions.scss
@@ -77,9 +77,7 @@
 
         .govuk-select {
             width: 100%;
-            @include govuk-media-query(tablet, 730px) {
-                min-width: calc(100% + 25px);
-            }
+            min-width: 100%;
         }
 
         .govuk-button {

--- a/assets/scss/decisions.scss
+++ b/assets/scss/decisions.scss
@@ -77,13 +77,15 @@
 
         .govuk-select {
             width: 100%;
+            @include govuk-media-query(tablet, 730px) {
+                min-width: calc(100% + 25px);
+            }
         }
 
         .govuk-button {
             margin-top: 20px;
         }
     }
-
 }
 
 .decision-count {

--- a/assets/scss/documents.scss
+++ b/assets/scss/documents.scss
@@ -71,6 +71,9 @@
 
     .govuk-select {
       width: 100%;
+      @include govuk-media-query(tablet, 730px) {
+        min-width: calc(100% + 25px);
+      }
     }
 
     .govuk-button {

--- a/assets/scss/documents.scss
+++ b/assets/scss/documents.scss
@@ -95,6 +95,10 @@
   .document-list-item {
     border-bottom: 1px solid $govuk-border-colour;
 
+    &__title {
+      margin-top: 15px;
+    }
+
     .document-published-date {
       @include govuk-font-size($size: 19);
       margin-bottom: 20px;

--- a/assets/scss/documents.scss
+++ b/assets/scss/documents.scss
@@ -71,9 +71,7 @@
 
     .govuk-select {
       width: 100%;
-      @include govuk-media-query(tablet, 730px) {
-        min-width: calc(100% + 25px);
-      }
+      min-width: 100%;
     }
 
     .govuk-button {

--- a/assets/scss/job-listings.scss
+++ b/assets/scss/job-listings.scss
@@ -1,6 +1,9 @@
 .job-listing-filter-form {
 	.govuk-select {
 		width: 100%;
+		@include govuk-media-query(tablet, 730px) {
+			min-width: calc(100% + 25px);
+		}
 	}
 }
 .job-list-item {

--- a/assets/scss/job-listings.scss
+++ b/assets/scss/job-listings.scss
@@ -1,9 +1,7 @@
 .job-listing-filter-form {
 	.govuk-select {
 		width: 100%;
-		@include govuk-media-query(tablet, 730px) {
-			min-width: calc(100% + 25px);
-		}
+		min-width: 100%;
 	}
 }
 .job-list-item {

--- a/assets/scss/listing.scss
+++ b/assets/scss/listing.scss
@@ -17,9 +17,7 @@
 
         .govuk-select {
           width: 100%;
-          @include govuk-media-query(tablet, 730px) {
-            min-width: calc(100% + 25px);
-          }
+          min-width: 100%;
         }
       }
     }

--- a/assets/scss/listing.scss
+++ b/assets/scss/listing.scss
@@ -10,15 +10,17 @@
           font-weight: bold;
           margin-top: 20px;
         }
-    
+
         .govuk-label {
           margin-top: 10px;
         }
-    
+
         .govuk-select {
           width: 100%;
+          @include govuk-media-query(tablet, 730px) {
+            min-width: calc(100% + 25px);
+          }
         }
-    
       }
     }
     .listing-item-count {

--- a/assets/scss/news.scss
+++ b/assets/scss/news.scss
@@ -40,6 +40,9 @@
 
     .govuk-select {
       width: 100%;
+      @include govuk-media-query(tablet, 730px) {
+        min-width: calc(100% + 25px);
+      }
     }
 
     .govuk-button {

--- a/assets/scss/news.scss
+++ b/assets/scss/news.scss
@@ -46,7 +46,6 @@
       margin-top: 20px;
     }
   }
-
 }
 
 .news-story-count {
@@ -58,6 +57,10 @@
 
 .news-story-list-item {
   border-bottom: 1px solid $govuk-border-colour;
+
+  &__title {
+    margin-top: 15px;
+  }
 
   &:last-child {
     border: none;

--- a/assets/scss/news.scss
+++ b/assets/scss/news.scss
@@ -40,9 +40,7 @@
 
     .govuk-select {
       width: 100%;
-      @include govuk-media-query(tablet, 730px) {
-        min-width: calc(100% + 25px);
-      }
+      min-width: 100%;
     }
 
     .govuk-button {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.4.5
+Version: 4.4.6
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe

--- a/template-parts/content-document-list-item.php
+++ b/template-parts/content-document-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="document-list-item">
-    <h2 class="document-list-item-title govuk-heading-m"><a
+    <h2 class="document-list-item__title"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="document-published-date">
         Published: <?php hale_posted_on(); ?>

--- a/template-parts/content-news-list-item.php
+++ b/template-parts/content-news-list-item.php
@@ -5,7 +5,7 @@
 ?>
 
 <div class="news-story-list-item">
-    <h2 class="news-story-list-item-title govuk-heading-m"><a
+    <h2 class="news-story-list-item__title"><a
             href="<?php echo get_permalink(); ?>"><?php echo get_the_title(); ?></a></h2>
     <div class="news-story-published-date">
         Published: <?php hale_posted_on(); ?>


### PR DESCRIPTION
This fixes 2 bugs:
- News and Documents title spacing - the heading was inheriting a 0 margin in the CSS, this specifies the correct margin.
  - Class name re-jig, the old class wasn't being used
  - Removed the `govuk-heading-m` class as this is implied from it being an H2, and there was a style clash.
- Select box filter
  - GDS have a `min-width` of 11.5em on their select boxes.  
  - 11.5em is less than our filter section and is causing issues at screen widths of between about 730px and mobile display.  
  - New min-width declared to override this.  


Tested in Chrome and Safari