### PR TITLE
Added deprecated paragraph switch

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1192,4 +1192,43 @@ function hale_add_blocks_settings( $wp_customize )
 			)
 		);
 	}
+
+	/*
+	* ------------------------------------------------------------
+	* SECTION: Deprecated switches
+	* ------------------------------------------------------------
+	*/
+	$wp_customize->add_section(
+		'deprecated_controls',
+		array(
+			'title'       => esc_html__( 'Deprecated controls', 'hale' ),
+			'description' => esc_attr__( 'Turn on and off deprecated support - preferably off', 'hale' ),
+			'priority'    => 100,
+		)
+	);
+
+	/*
+	* -----------------------------------------------------------
+	* Paragraph Widths Support
+	* -----------------------------------------------------------
+	*/
+	$wp_customize->add_setting(
+		'deprecated_paragraph_widths',
+		array(
+			'default'           => 'no',
+			'sanitize_callback' => 'hale_sanitize_select',
+		)
+	);
+	$wp_customize->add_control(
+		'deprecated_paragraph_widths',
+		array(
+			'label'       => esc_html__( 'Disable the new narrow paragraphs for this site', 'hale' ),
+			'section'     => 'deprecated_controls',
+			'type'        => 'radio',
+			'choices'     => array(
+				'yes' => esc_html__( 'Yes', 'hale' ),
+				'no'  => esc_html__( 'No', 'hale' ),
+			),
+		)
+	);
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -255,6 +255,34 @@ function hale_admin_custom_typography( $classes ) {
 add_filter( 'admin_body_class', 'hale_admin_custom_typography', 10, 1);
 
 /**
+ * Deprecation handling
+ */
+function hale_get_deprecation_class() {
+	$class = "";
+	$deprecated_paragraph_widths = get_theme_mod( 'deprecated_paragraph_widths', 'no' );
+	if ($deprecated_paragraph_widths == "yes") $class = "hale-deprecated-paragraph-widths";
+	return $class;
+}
+function hale_deprecation( $classes ) {
+	$classes[] .= hale_get_deprecation_class();
+	return $classes;
+}
+add_filter( 'body_class', 'hale_deprecation' );
+
+function hale_admin_deprecation( $classes ) {
+    global $pagenow;
+
+    if ( 'post.php' !== $pagenow && 'post-new.php' !== $pagenow ) {
+        return;
+    }
+
+	$classes .= ' '.hale_get_deprecation_class();
+	return $classes;
+}
+add_filter( 'admin_body_class', 'hale_admin_deprecation', 10, 1);
+
+
+/**
  * Function to sanitise content and remove empty elements that cause a11y and w3c validation errors.
  *
  * @param bool $b_print Boolean argument specifying whether or not to print the function output.

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.4.7
+Version: 4.4.8
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
This adds:
- a deprecated section to the Customizer
- the switch for deprecated paragraph widths.
- a class to the front end and backend if deprecated paragraphs is "yes".
- nothing else - so this does nothing at all in practice, aside from enabling the switch in preparation for the following PR.