### PR TITLE
Dark background - doesn't really do anything

### DIFF
--- a/assets/scss/brandings-dark-background--php-used.scss
+++ b/assets/scss/brandings-dark-background--php-used.scss
@@ -40,11 +40,13 @@
 		&:is(p),
 		p,
 		li,
-		label {
+		label,
+		.use-text-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-text));
 		}
 		h1, h2, h3, h4, h5, h6,
-		&:is(h1, h2, h3, h4, h5, h6) {
+		&:is(h1, h2, h3, h4, h5, h6),
+		.use-heading-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-heading-text));
 		}
 	}

--- a/assets/scss/brandings-dark-background--php-used.scss
+++ b/assets/scss/brandings-dark-background--php-used.scss
@@ -53,13 +53,15 @@
 	&:is(p),
 	p,
 	li,
-	label {
+	label,
+	.use-dark-background-text-colour {
 		&.#{$paletteColour}:not(.has-text-color) {
 			color: var(--dark-text);
 		}
 	}
 	h1, h2, h3, h4, h5, h6,
-	&:is(h1, h2, h3, h4, h5, h6) {
+	&:is(h1, h2, h3, h4, h5, h6),
+	.use-dark-background-heading-colour {
 		&.#{$paletteColour}:not(.has-text-color) {
 			color: var(--dark-heading-text);
 		}

--- a/assets/scss/brandings-dark-background--php-used.scss
+++ b/assets/scss/brandings-dark-background--php-used.scss
@@ -41,12 +41,12 @@
 		p,
 		li,
 		label,
-		.use-text-colour {
+		.use-dark-background-text-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-text));
 		}
 		h1, h2, h3, h4, h5, h6,
 		&:is(h1, h2, h3, h4, h5, h6),
-		.use-heading-colour {
+		.use-dark-background-heading-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-heading-text));
 		}
 	}

--- a/assets/scss/brandings-dark-background--php-used.scss
+++ b/assets/scss/brandings-dark-background--php-used.scss
@@ -6,6 +6,8 @@
 	This file creates the CSS for a dark background, but it uses the class "has-replace_replace-background-color" (which isn't used).
 	We use this CSS in PHP (colour-branding.php) to apply the style should the colour chosen be calculated to be dark.
 	So whilst this CSS is not directly used by anything, it is copied by the PHP, amended and added where needed.
+
+	Note that any changes to this file might need a colour refresh as this creates the CSS via PHP.
 *******/
 
 @mixin hale-block-inside-block($paletteColour, $colour, $hoverColour: "") {

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -46,11 +46,13 @@
 		&:is(p),
 		p,
 		li,
-		label {
+		label,
+		.use-text-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-text));
 		}
 		h1, h2, h3, h4, h5, h6,
-		&:is(h1, h2, h3, h4, h5, h6) {
+		&:is(h1, h2, h3, h4, h5, h6),
+		.use-heading-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-heading-text));
 		}
 	}

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -47,12 +47,12 @@
 		p,
 		li,
 		label,
-		.use-text-colour {
+		.use-dark-background-text-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-text));
 		}
 		h1, h2, h3, h4, h5, h6,
 		&:is(h1, h2, h3, h4, h5, h6),
-		.use-heading-colour {
+		.use-dark-background-heading-colour {
 			@include hale-block-inside-block($paletteColour,var(--dark-heading-text));
 		}
 	}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.4.9
+Version: 4.4.10
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
This is groundwork for changes that will follow in the Quote block, and maybe elsewhere.  

It adds classes which can be used to get the text/heading colour for dark backgrounds.  
- `use-dark-background-text-colour`
- `use-dark-background-heading-colour`

The new classes are not yet used, so this can be merged with no actual changes being realized.  Co-ordinated deployment not required.