### PR TITLE
GDS colours overwritten bug

### DIFF
--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -1,6 +1,7 @@
 //brandings for MoJ Blocks
 
-body.hale-colours-variable {
+body.hale-colours-variable,
+body.hale-colours-gds-standard {
 	//Accordion block
 	.govuk-accordion,
 	.js-enabled .govuk-accordion {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.4.10
+Version: 4.4.11
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe


### PR DESCRIPTION
Some "GDS" colours were being overwritten by some CSS added elsewhere.  

This was affecting the staggered box on Magistrates Recruitment.

This increases the specificity of the GDS colour CSS to match that of the colour variable declarations.  The two should now be in synch.  