### PR TITLE
Remove dashboard metaboxes & update style.css

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -371,6 +371,11 @@ require get_template_directory() . '/inc/flexible-cpts.php';
 require get_template_directory() . '/inc/flexible-taxonomies.php';
 
 /**
+ * Custom template tags for this theme.
+ */
+require get_template_directory() . '/inc/dashboard-customisations.php';
+
+/**
  * Create an array of active plugins.
  */
 

--- a/inc/dashboard-customisations.php
+++ b/inc/dashboard-customisations.php
@@ -1,0 +1,10 @@
+<?php
+
+// Remove some of the boxes from dashboard we don't need, make things less cluttered
+function hale_remove_dashboard_metabox() {
+    remove_meta_box('dashboard_primary', 'dashboard', 'side'); // WordPress News
+    remove_meta_box('wpseo-dashboard-overview', 'dashboard', 'normal');
+    remove_meta_box('dashboard_site_health', 'dashboard', 'normal');
+}
+
+add_action('admin_init', 'hale_remove_dashboard_metabox');

--- a/style.css
+++ b/style.css
@@ -1,8 +1,12 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.4.11
+Version: 4.5.1
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
-Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
+Author: Ministry of Justice
+Author URI: https://www.gov.uk/government/organisations/ministry-of-justice
+Tags: government, clean, responsive, accessibility
+License: MIT
+License URI: https://opensource.org/licenses/MIT
 */


### PR DESCRIPTION
* Add section responsible to remove metaboxes we don't really need to have presented to editors.
This includes, WordPress news and WP health checker (which doesn't work with our hosting architecture)

* Update style.css