### PR TITLE
Hero minor fix

### DIFF
--- a/assets/scss/moj-blocks-general.scss
+++ b/assets/scss/moj-blocks-general.scss
@@ -60,6 +60,14 @@
       right: 0;
       margin: 0;
 
+      @include govuk-media-query($from: 1020px) {
+        &__overlay {
+          margin-left: 1rem;
+          margin-right: 1rem;
+          width: calc(100% - 2rem);
+        }
+      }
+
       @include govuk-media-query($until: desktop) {
         margin-top:10px;
       }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.5.1
+Version: 4.5.2
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
This corrects the margins of the overlay when the Hero banner is used in Hale's default template.  