### PR TITLE
Taxonomies and Published Dates

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -629,7 +629,8 @@ html.hale-page {
 	.news-story-published-date {
 		color: var(--text);
 	}
-	.news-story-category-link {
+	.news-story-category-link,
+	.flexible-post-type-tags-link {
 		color: var(--tag-text);
 		background: var(--tag-bg);
 

--- a/assets/scss/flexible-post-types.scss
+++ b/assets/scss/flexible-post-types.scss
@@ -19,5 +19,35 @@
       }
     }
 
+    .flexible-post-type-tags {
+    
+      .flexible-post-type-tags-list {
+        list-style: none;
+        padding: 0;
+        margin-top: 0;
+    
+        .flexible-post-type-tags-list-item {
+          display: inline-block;
+          margin-top:0.4rem;
+          margin-bottom:0.4rem;
+    
+          .flexible-post-type-tags-link {
+            font-weight: bold;
+            border-radius: 4px;
+            padding: 4px 8px;
+            text-decoration: none;
+            margin-right: 15px;
+            text-align: center;
+    
+            &:focus {
+              outline-style: solid;
+              outline-width: 2px;
+              outline-offset: 0;
+            }
+          }
+        }
+      }
+    }
+
   }
 }

--- a/assets/scss/flexible-post-types.scss
+++ b/assets/scss/flexible-post-types.scss
@@ -7,6 +7,17 @@
         font-weight: normal;
       }
     }
+
+    .flexible-post-type-published-date {
+      @include govuk-font-size($size: 19);
+      margin-bottom: 20px;
+
+      .flexible-post-type-published-date-label {
+        font-weight: bold;
+        display: inline-block;
+      }
+    }
+    
     .flexible-post-type-details {
       .flexible-post-type-detail {
         @include govuk-font-size($size: 19);

--- a/functions.php
+++ b/functions.php
@@ -390,6 +390,7 @@ require get_template_directory() . '/inc/flexible-taxonomies.php';
 
  // Admin changes
 require get_template_directory() . '/inc/acf/admin/settings.php';
+require get_template_directory() . '/inc/acf/admin/post-display-settings.php';
 
 // General utilities
 require get_template_directory() . '/inc/acf/utilities.php';

--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -8,6 +8,9 @@ add_filter( 'acf/post_type/additional_settings_tabs', function ( $tabs ) {
 } );
 
 add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_post_type) {
+
+    echo '<div class="acf-label"><label for="acf_post_type-admin_menu_parent" style="font-weight:500;">Single view</label></div>';
+    echo '<div class="acf-field acf-field-seperator" data-type="seperator" style="margin-top: 15px;"></div>';
     
     acf_render_field_wrap(
         array(

--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -9,10 +9,22 @@ add_filter( 'acf/post_type/additional_settings_tabs', function ( $tabs ) {
 
 add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_post_type) {
     
-    
     acf_render_field_wrap(
         array(
-            'label' => 'Show taxonomies on single view',
+            'label' => 'Show Published Date',
+            'instructions' => 'Shows published date on the single view.',
+            'name'         => 'show_published_date_on_single_view',
+            'value'        => isset( $acf_post_type['show_published_date_on_single_view'] ) ? $acf_post_type['show_published_date_on_single_view'] : true,
+            'prefix'       => 'acf_post_type',
+            'type' => 'true_false',
+            'key' => 'show_published_date_on_single_view',
+            'ui' => true,
+        )
+    );
+
+    acf_render_field_wrap(
+        array(
+            'label' => 'Show Taxonomies',
             'instructions' => 'Shows taxonomy terms on the single view.',
             'name'         => 'show_tax_on_single_view',
             'value'        => isset( $acf_post_type['show_tax_on_single_view'] ) ? $acf_post_type['show_tax_on_single_view'] : false,
@@ -24,7 +36,7 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
     );
     acf_render_field_wrap(
         array(
-            'label' => 'Single view single taxonomy style',
+            'label' => 'Single view taxonomy style',
             'instructions' => '',
             'name'         => 'single_view_tax_style',
             'prefix'       => 'acf_post_type',
@@ -48,6 +60,9 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
 });
 
 add_filter( 'acf/post_type/registration_args', function( $args, $post_type ) {
+    if ( isset( $post_type['show_tax_on_single_view'] ) ) {
+        $args['show_published_date_on_single_view'] = (bool) $post_type['show_published_date_on_single_view'];
+    }
     if ( isset( $post_type['show_tax_on_single_view'] ) ) {
         $args['show_tax_on_single_view'] = (bool) $post_type['show_tax_on_single_view'];
     }

--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -1,0 +1,59 @@
+<?php
+
+
+add_filter( 'acf/post_type/additional_settings_tabs', function ( $tabs ) {
+    $tabs['display-settings'] = 'Display Settings';
+
+    return $tabs;
+} );
+
+add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_post_type) {
+    
+    
+    acf_render_field_wrap(
+        array(
+            'label' => 'Show taxonomies on single view',
+            'instructions' => 'Shows taxonomy terms on the single post view.',
+            'name'         => 'show_tax_on_single_view',
+            'value'        => isset( $acf_post_type['show_tax_on_single_view'] ) ? $acf_post_type['show_tax_on_single_view'] : false,
+            'prefix'       => 'acf_post_type',
+            'type' => 'true_false',
+            'key' => 'show_tax_on_single_view',
+            'ui' => true,
+        )
+    );
+    acf_render_field_wrap(
+        array(
+            'label' => 'Taxonomy single view style',
+            'instructions' => 'Which style taxonomy terms are shown on the single post view.',
+            'name'         => 'single_view_tax_style',
+            'prefix'       => 'acf_post_type',
+            'value'        => isset( $acf_post_type['single_view_tax_style'] ) ? $acf_post_type['single_view_tax_style'] : '',
+            'type'         => 'select',
+            'choices' => array(
+				'list' => 'List',
+				'tags' => 'Tags',
+			),
+            'conditional_logic' => array(
+				array(
+					array(
+						'field' => 'show_tax_on_single_view',
+						'operator' => '==',
+						'value' => '1',
+					),
+				),
+			),
+        )
+    );
+});
+
+add_filter( 'acf/post_type/registration_args', function( $args, $post_type ) {
+    if ( isset( $post_type['show_tax_on_single_view'] ) ) {
+        $args['show_tax_on_single_view'] = (bool) $post_type['show_tax_on_single_view'];
+    }
+    if ( isset( $post_type['single_view_tax_style'] ) ) {
+        $args['single_view_tax_style'] = $post_type['single_view_tax_style'];
+    }
+
+    return $args;
+}, 10, 2 );

--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -13,7 +13,7 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
     acf_render_field_wrap(
         array(
             'label' => 'Show taxonomies on single view',
-            'instructions' => 'Shows taxonomy terms on the single post view.',
+            'instructions' => 'Shows taxonomy terms on the single view.',
             'name'         => 'show_tax_on_single_view',
             'value'        => isset( $acf_post_type['show_tax_on_single_view'] ) ? $acf_post_type['show_tax_on_single_view'] : false,
             'prefix'       => 'acf_post_type',
@@ -24,8 +24,8 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
     );
     acf_render_field_wrap(
         array(
-            'label' => 'Taxonomy single view style',
-            'instructions' => 'Which style taxonomy terms are shown on the single post view.',
+            'label' => 'Single view single taxonomy style',
+            'instructions' => '',
             'name'         => 'single_view_tax_style',
             'prefix'       => 'acf_post_type',
             'value'        => isset( $acf_post_type['single_view_tax_style'] ) ? $acf_post_type['single_view_tax_style'] : '',

--- a/inc/acf/utilities.php
+++ b/inc/acf/utilities.php
@@ -32,3 +32,27 @@ function hale_get_acf_field_status($field) {
 
     return false;
 }
+
+/**
+ * Checks the status of a specific setting for the current post type.
+ *
+ * @param string $setting The name of the setting to check.
+ *
+ * @return bool Returns value of setting for the current post type. Returns false if setting not found.
+ *
+ */
+function hale_get_post_type_setting($setting) {
+    $current_post_type = get_post_type();
+
+    if (!$current_post_type) {
+        return false;
+    }
+
+    $post_types = get_post_types([], 'objects');
+
+    if (isset($post_types[$current_post_type]->$setting)) {
+        return $post_types[$current_post_type]->$setting;
+    }
+
+    return false;
+}

--- a/inc/flexible-cpts.php
+++ b/inc/flexible-cpts.php
@@ -522,7 +522,7 @@ function hale_add_taxonomy_acf_field($tax) {
 
 
 /**
- * Adds an Dropdown (select) ACF Field for a specific post type. Which lists acf fields assigned to a post type. Currently only on listing page template.
+ * Adds an Dropdown (select) ACF Field for a specific post type. Which lists acf fields and taxonomies assigned to a post type. Currently only on listing page template.
  *
  * @param object $post_type The post type object.
  * @param string $field_key The ACF field key.
@@ -538,6 +538,12 @@ function hale_add_custom_fields_select_acf_field($post_type, $field_key, $field_
 
     if (isset($post_type->post_summary) && $post_type->post_summary == '1') {
         $choices[$post_type->name . '_summary'] = "Summary";
+    }
+
+    $taxonomies = get_object_taxonomies($post_type->name, 'objects');
+
+    foreach($taxonomies as $tax) {
+        $choices[$tax->name] = $tax->label;
     }
 
     $groups = acf_get_field_groups(array('post_type' => $post_type->name)); 

--- a/page-listing.php
+++ b/page-listing.php
@@ -266,7 +266,15 @@ while (have_posts()) :
                     foreach($selected_display_fields as $field){
 
                         if($field == 'published-date'){
-                            $display_fields[] = ["name" => "published-date", "label" => "Published"];
+                            $display_fields[] = ["name" => "published-date", "label" => "Published", "type" => "published-date"];
+                            continue;
+                        }
+
+                        if(taxonomy_exists($field)){
+
+                            $tax = get_taxonomy($field);
+
+                            $display_fields[] = ["name" =>  $field, "label" =>  $tax->label, "type" => "taxonomy"];
                             continue;
                         }
 
@@ -280,7 +288,7 @@ while (have_posts()) :
                                 $field_object['label'] = '';
                                 $field_object['wpautop'] = true;
                             }
-                            $display_fields[] = $field_object;
+                            $display_fields[] = [ "name" => $field_object['name'], "label" => $field_object['label'], "type" => "post_meta"];
                         }
                        
                     }

--- a/template-parts/content-documents.php
+++ b/template-parts/content-documents.php
@@ -61,15 +61,15 @@ if ($file) {
 }
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class(array('flexible-post-type-single')); ?>>
 	<?php
 		the_title( '<h1 class="document-title govuk-heading-xl">', '</h1>' );
 	?>
-    <div class="document-details">
-        <div class="document-published-date">
-            Published: <?php hale_posted_on(); ?>
-        </div>
+    <div class="flexible-post-type-published-date">
+            <div class="flexible-post-type-published-date-label">Published: </div>
+            <?php hale_posted_on(); ?>
     </div>
+	<?php get_template_part( 'template-parts/flexible-cpts/details'); ?>
 	<div class="document-summary">
 		<?php if ($file) { ?>
 			<?php if (!$icon_image) { ?>

--- a/template-parts/flexible-cpts/details.php
+++ b/template-parts/flexible-cpts/details.php
@@ -11,29 +11,33 @@
     <?php 
     
     $groups = acf_get_field_groups(array('post_type' => $post_type)); 
-    
+
     if(is_array($groups) && count($groups) > 0){
 
         foreach($groups as $group) {
 
             $fields = acf_get_fields($group['key']);
 
-            if(is_array($fields) && count($fields) > 0){
-
-                foreach($fields as $field){
-                    
-                    $field_value = get_field($field['name']);
-
-                    if(!empty($field_value) && $field["single_view"]){
-                        ?>
-                            <div class="flexible-post-type-detail">
-                                <div class="flexible-post-type-detail-label"><?php echo $field['label']; ?>: </div>
-                                <?php echo $field_value; ?>
-                            </div>
-                        <?php
-                    }
-                }
+            if (empty($fields)) {
+                continue;
             }
+
+            foreach($fields as $field){
+                
+                $field_value = get_field($field['name']);
+
+                if(empty($field_value) || !array_key_exists('single_view',  $field) || !$field["single_view"]){
+                    continue;
+                }
+                ?>
+                    <div class="flexible-post-type-detail">
+                        <div class="flexible-post-type-detail-label"><?php echo $field['label']; ?>: </div>
+                        <?php echo esc_html($field_value); ?>
+                    </div>
+                <?php
+                
+            }
+            
         }
     }
 

--- a/template-parts/flexible-cpts/details.php
+++ b/template-parts/flexible-cpts/details.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Template part for displaying fleixble details. Displays custom fields and taxonomeis as list or tags.
+ */
+
+ $post_type = get_post_type();
+ 
+?>
+
+<div class="flexible-post-type-details">
+    <?php 
+    
+    $groups = acf_get_field_groups(array('post_type' => $post_type)); 
+    
+    if(is_array($groups) && count($groups) > 0){
+
+        foreach($groups as $group) {
+
+            $fields = acf_get_fields($group['key']);
+
+            if(is_array($fields) && count($fields) > 0){
+
+                foreach($fields as $field){
+                    
+                    $field_value = get_field($field['name']);
+
+                    if(!empty($field_value) && $field["single_view"]){
+                        ?>
+                            <div class="flexible-post-type-detail">
+                                <div class="flexible-post-type-detail-label"><?php echo $field['label']; ?>: </div>
+                                <?php echo $field_value; ?>
+                            </div>
+                        <?php
+                    }
+                }
+            }
+        }
+    }
+
+    $show_tax_on_single_view = hale_get_acf_field_status('show_tax_on_single_view');
+
+    $single_view_tax_style = hale_get_post_type_setting('single_view_tax_style'); 
+
+    if($show_tax_on_single_view){
+
+        $current_post_type = get_post_type();
+
+        $taxonomies = get_object_taxonomies($current_post_type);
+
+        $tax_details = [];
+
+        foreach($taxonomies as $tax){
+
+
+            $tax_obj = get_taxonomy( $tax );
+            $tax_terms = get_the_terms( get_the_ID(), $tax);
+
+            if(!empty($tax_terms)){
+
+                $tax_details[] = [
+                    'slug' => $tax,
+                    'label' => $tax_obj->label,
+                    'terms' => $tax_terms
+                ];
+            }
+
+        }
+
+        if($single_view_tax_style == 'list' && !empty($tax_details)){
+
+            foreach($tax_details as $tax){
+
+                $term_names = [];
+                foreach ($tax['terms'] as $term) {
+                    $term_names[] = $term->name;
+                }
+
+                if(empty($term_names)){
+                    continue;
+                }
+
+                ?>
+                <div class="flexible-post-type-detail">
+                    <div class="flexible-post-type-detail-label"><?php echo $tax['label'];?>: </div>
+                    <?php echo implode("," , $term_names); ?>
+                </div>
+                <?php
+            }
+        }
+
+    }
+    ?>
+
+
+</div>
+
+<?php
+//Tags Section
+
+if($show_tax_on_single_view && $single_view_tax_style == 'tags' && !empty($tax_details)){
+
+?>
+    <div class="flexible-post-type-tags">
+        <ul class="flexible-post-type-tags-list"> 
+            <?php
+            foreach($tax_details as $tax){
+                foreach ($tax['terms'] as $term) { ?>
+                <li class="flexible-post-type-tags-list-item">
+                    <a href="<?php echo get_term_link($term); ?>"
+                        class="flexible-post-type-tags-link">
+                        <?php echo $term->name; ?>
+                    </a>
+                </li>
+            <?php 
+                }
+            } ?>
+        </ul>
+
+    </div>
+<?php } ?>
+
+ 

--- a/template-parts/flexible-cpts/list-item.php
+++ b/template-parts/flexible-cpts/list-item.php
@@ -24,8 +24,25 @@
 
         foreach($display_fields as $field){
 
-            if($field['name'] == 'published-date'){
+            $field_value = "";
+
+            if($field['type'] == 'published-date'){
                 $field_value =  '<time class="entry-date published-date" datetime="' . get_the_date( DATE_W3C ) . '">' . get_the_date() . '</time>';
+            }
+            else if($field['type'] == 'taxonomy'){
+                $tax_terms = get_the_terms( get_the_ID(), $field['name'] );
+
+                if(!empty($tax_terms)){
+
+                    $term_names = [];
+                    foreach ($tax_terms as $term) {
+                        $term_names[] = $term->name;
+                    }
+
+                    if(!empty($term_names)){
+                        $field_value = implode("," , $term_names);
+                    }
+                }
             }
             else {
                 $field_value = get_field($field['name']);

--- a/template-parts/flexible-cpts/single.php
+++ b/template-parts/flexible-cpts/single.php
@@ -3,8 +3,6 @@
  * Template part for displaying fleixble cpt of type simple
  */
 
- $post_type = get_post_type();
- 
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(array('flexible-post-type-single')); ?>>
@@ -15,11 +13,16 @@
 
         ?>
     </header>
-    <div class="flexible-post-type-published-date">
-            <div class="flexible-post-type-published-date-label">Published: </div>
-            <?php hale_posted_on(); ?>
-    </div>
+    <?php
+     $show_published_date_on_single_view = hale_get_acf_field_status('show_published_date_on_single_view');
 
+     if($show_published_date_on_single_view){
+     ?>
+        <div class="flexible-post-type-published-date">
+                <div class="flexible-post-type-published-date-label">Published: </div>
+                <?php hale_posted_on(); ?>
+        </div>
+    <?php } ?>
     <?php get_template_part( 'template-parts/flexible-cpts/details'); ?>
     
     <?php do_action('hale_before_single_content'); ?>

--- a/template-parts/flexible-cpts/single.php
+++ b/template-parts/flexible-cpts/single.php
@@ -15,122 +15,13 @@
 
         ?>
     </header>
-    <div class="flexible-post-type-details">
-        <div class="flexible-post-type-detail">
-            <div class="flexible-post-type-detail-label">Published: </div>
+    <div class="flexible-post-type-published-date">
+            <div class="flexible-post-type-published-date-label">Published: </div>
             <?php hale_posted_on(); ?>
-        </div>
-		<?php 
-        
-        $groups = acf_get_field_groups(array('post_type' => $post_type)); 
-		
-        if(is_array($groups) && count($groups) > 0){
+    </div>
 
-            foreach($groups as $group) {
-
-                $fields = acf_get_fields($group['key']);
-
-                if(is_array($fields) && count($fields) > 0){
-
-                    foreach($fields as $field){
-                        
-                        $field_value = get_field($field['name']);
-
-                        if(!empty($field_value) && $field["single_view"]){
-                            ?>
-                                <div class="flexible-post-type-detail">
-                                    <div class="flexible-post-type-detail-label"><?php echo $field['label']; ?>: </div>
-                                    <?php echo $field_value; ?>
-                                </div>
-                            <?php
-                        }
-                    }
-                }
-            }
-        }
-
-        $show_tax_on_single_view = hale_get_acf_field_status('show_tax_on_single_view');
-
-        $single_view_tax_style = hale_get_post_type_setting('single_view_tax_style'); 
-
-        if($show_tax_on_single_view){
-
-            $current_post_type = get_post_type();
-
-            $taxonomies = get_object_taxonomies($current_post_type);
-
-            $tax_details = [];
-
-            foreach($taxonomies as $tax){
-
-
-                $tax_obj = get_taxonomy( $tax );
-                $tax_terms = get_the_terms( get_the_ID(), $tax);
-
-                if(!empty($tax_terms)){
-
-                    $tax_details[] = [
-                        'slug' => $tax,
-                        'label' => $tax_obj->label,
-                        'terms' => $tax_terms
-                    ];
-                }
-
-            }
-
-            if($single_view_tax_style == 'list' && !empty($tax_details)){
-
-                foreach($tax_details as $tax){
-
-                    $term_names = [];
-                    foreach ($tax['terms'] as $term) {
-                        $term_names[] = $term->name;
-                    }
-
-                    if(empty($term_names)){
-                        continue;
-                    }
-
-                    ?>
-                    <div class="flexible-post-type-detail">
-                        <div class="flexible-post-type-detail-label"><?php echo $tax['label'];?>: </div>
-                        <?php echo implode("," , $term_names); ?>
-                    </div>
-                    <?php
-                }
-            }
-
-        }
-		?>
-
-
-	</div>
-
-    <?php
-    //Tags Section
-
-    if($show_tax_on_single_view && $single_view_tax_style == 'tags' && !empty($tax_details)){
-
-    ?>
-        <div class="flexible-post-type-tags">
-            <ul class="flexible-post-type-tags-list"> 
-                <?php
-                foreach($tax_details as $tax){
-                    foreach ($tax['terms'] as $term) { ?>
-                    <li class="flexible-post-type-tags-list-item">
-                        <a href="<?php echo get_term_link($term); ?>"
-                            class="flexible-post-type-tags-link">
-                            <?php echo $term->name; ?>
-                        </a>
-                    </li>
-                <?php 
-                    }
-                } ?>
-            </ul>
-
-        </div>
-    <?php } ?>
-
+    <?php get_template_part( 'template-parts/flexible-cpts/details'); ?>
+    
     <?php do_action('hale_before_single_content'); ?>
 
     <div class="flexible-post-type-content">

--- a/template-parts/flexible-cpts/single.php
+++ b/template-parts/flexible-cpts/single.php
@@ -16,6 +16,10 @@
         ?>
     </header>
     <div class="flexible-post-type-details">
+        <div class="flexible-post-type-detail">
+            <div class="flexible-post-type-detail-label">Published: </div>
+            <?php hale_posted_on(); ?>
+        </div>
 		<?php 
         
         $groups = acf_get_field_groups(array('post_type' => $post_type)); 
@@ -27,7 +31,7 @@
                 $fields = acf_get_fields($group['key']);
 
                 if(is_array($fields) && count($fields) > 0){
-                    
+
                     foreach($fields as $field){
                         
                         $field_value = get_field($field['name']);
@@ -44,10 +48,88 @@
                 }
             }
         }
+
+        $show_tax_on_single_view = hale_get_acf_field_status('show_tax_on_single_view');
+
+        $single_view_tax_style = hale_get_post_type_setting('single_view_tax_style'); 
+
+        if($show_tax_on_single_view){
+
+            $current_post_type = get_post_type();
+
+            $taxonomies = get_object_taxonomies($current_post_type);
+
+            $tax_details = [];
+
+            foreach($taxonomies as $tax){
+
+
+                $tax_obj = get_taxonomy( $tax );
+                $tax_terms = get_the_terms( get_the_ID(), $tax);
+
+                if(!empty($tax_terms)){
+
+                    $tax_details[] = [
+                        'slug' => $tax,
+                        'label' => $tax_obj->label,
+                        'terms' => $tax_terms
+                    ];
+                }
+
+            }
+
+            if($single_view_tax_style == 'list' && !empty($tax_details)){
+
+                foreach($tax_details as $tax){
+
+                    $term_names = [];
+                    foreach ($tax['terms'] as $term) {
+                        $term_names[] = $term->name;
+                    }
+
+                    if(empty($term_names)){
+                        continue;
+                    }
+
+                    ?>
+                    <div class="flexible-post-type-detail">
+                        <div class="flexible-post-type-detail-label"><?php echo $tax['label'];?>: </div>
+                        <?php echo implode("," , $term_names); ?>
+                    </div>
+                    <?php
+                }
+            }
+
+        }
 		?>
 
 
 	</div>
+
+    <?php
+    //Tags Section
+
+    if($show_tax_on_single_view && $single_view_tax_style == 'tags' && !empty($tax_details)){
+
+    ?>
+        <div class="flexible-post-type-tags">
+            <ul class="flexible-post-type-tags-list"> 
+                <?php
+                foreach($tax_details as $tax){
+                    foreach ($tax['terms'] as $term) { ?>
+                    <li class="flexible-post-type-tags-list-item">
+                        <a href="<?php echo get_term_link($term); ?>"
+                            class="flexible-post-type-tags-link">
+                            <?php echo $term->name; ?>
+                        </a>
+                    </li>
+                <?php 
+                    }
+                } ?>
+            </ul>
+
+        </div>
+    <?php } ?>
 
     <?php do_action('hale_before_single_content'); ?>
 


### PR DESCRIPTION
 Listing Page: Adds option to display fields so you can display taxonomies

CPT settings: 

- Add display settings - advanced tab
- Toggle Published Date on/off on single view
- Toggle Taxonomies on/off on single view
- Dropdown select to decide in taxonomies show as list or tags

Side note:

We havent merged the docs single and flex single template yet as this would require a show summary toggle which is part of the news migration

We havent added the show_published_date_on_single_view on the doc single as we first need to roll out the published date toggle. 
