### PR TITLE
Update class

### DIFF
--- a/assets/scss/brandings-dark-background--php-used.scss
+++ b/assets/scss/brandings-dark-background--php-used.scss
@@ -71,6 +71,6 @@
 }
 
 * main,
-* .edit-post-visual-editor__content-area {
+body.hale-editor .edit-post-visual-editor {
 	@include hale-custom-shading-text-colours("has-replace_replace-background-color");
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.8.0
+Version: 4.8.1
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
A wordpress version upgrade changed the classname which we were relying on here.  This PR changes the CSS to use a classname which is still used.  

Effect - the editor screen now displays text on a dark background correctly.  The frontend was working okay as it wasn't reliant on this class.