### PR TITLE
More button focus

### DIFF
--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -78,10 +78,14 @@
                 transform: rotate(45deg);
               }
             }
-            ~ .menu-item,
-              .menu-item--more__content {
+            ~ .menu-item {
                 display: none;
             }
+            .menu-item--more__content {
+                display: flex;
+                visibility: hidden;
+                transition: visibility  0s 1ms;
+              }
             &--open {
               .menu-item__more:after {
                 transform: rotate(-135deg);
@@ -91,9 +95,10 @@
 
             &--open .menu-item--more__content,
             &:hover .menu-item--more__content,
+            .menu-item__more:focus ~ .menu-item--more__content,
             .menu-item--more__content:focus,
             .menu-item--more__content:focus-within {
-              display: flex;
+              visibility: visible;
             }
           }
           .menu-item--more__content {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.10.4
+Version: 4.10.5
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
Changed the CSS to allow the more button's content to be visible when the more button is tabbed to.  
- Changed `display:none` to `visibility:hidden`, so a transition can be used.
- Transition used to ensure there is a small delay in hiding the menu, this delay is long enough so the focus can be successfully transferred to the menu hidden by the more button. 