### PR TITLE
Submenu background

### DIFF
--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -381,6 +381,7 @@
           list-style: none;
           display: none;
           min-width: 100%;
+          background-color: govuk-colour("black"); // fallback, should be overwritten by custom colour
 
           &:not(.js-enabled .sub-menu) {
             // ensure submenu visible when no JS

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.15.2
+Version: 4.15.3
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
When the custom colour failed (hopefully fixed in the previous PR), the most serious issue was the background colour for submenus being transparent.  

This adds a fallback to keep the background black (same as header).  