### PR TITLE
New Table of Contents and Numbering functionality for single custom post

### DIFF
--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -453,3 +453,15 @@
     }
   }
 }
+
+// Table of contents styling
+
+.hale-table-of-contents {
+  padding: 1.1rem 0.5rem 1.1rem 1.1rem;
+  ol {
+    margin-bottom:0;
+  }
+  li {
+    padding: 0.2rem 0;
+  }
+}

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -457,9 +457,11 @@
 // Table of contents styling
 
 .hale-table-of-contents {
-  padding: 1.1rem 0.5rem 1.1rem 1.1rem;
-  ol {
-    margin-bottom:0;
+  @include govuk-media-query($from: desktop) {
+    padding: 1.1rem 0.5rem 1.1rem 1.1rem;
+    ol {
+      margin-bottom: 0;
+    }
   }
   li {
     padding: 0.2rem 0;

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -458,7 +458,7 @@
 
 .hale-table-of-contents {
   @include govuk-media-query($from: desktop) {
-    padding: 1.1rem 0.5rem 1.1rem 1.1rem;
+    padding: 0.5rem 0.5rem 1.1rem 0rem;
     ol {
       margin-bottom: 0;
     }

--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -49,6 +49,50 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
 
     acf_render_field_wrap(
         array(
+            'label' => 'Show Table of Contents',
+            'instructions' => 'Shows table of contents at the side.',
+            'name'         => 'show_toc_on_single_view',
+            'value'        => isset( $acf_post_type['show_toc_on_single_view'] ) ? $acf_post_type['show_toc_on_single_view'] : false,
+            'prefix'       => 'acf_post_type',
+            'type' => 'true_false',
+            'key' => 'show_toc_on_single_view',
+            'ui' => true,
+            'conditional_logic' => array(
+				array(
+					array(
+						'field' => 'post_toc',
+						'operator' => '==',
+						'value' => '1',
+					),
+				),
+			),
+        )
+    );
+
+    acf_render_field_wrap(
+        array(
+            'label' => 'Number headings',
+            'instructions' => 'Add numbers to the H2 headings.',
+            'name'         => 'number_headings',
+            'value'        => isset( $acf_post_type['number_headings'] ) ? $acf_post_type['number_headings'] : false,
+            'prefix'       => 'acf_post_type',
+            'type' => 'true_false',
+            'key' => 'number_headings',
+            'ui' => true,
+            'conditional_logic' => array(
+				array(
+					array(
+						'field' => 'post_number_headings',
+						'operator' => '==',
+						'value' => '1',
+					),
+				),
+			),
+        )
+    );
+
+    acf_render_field_wrap(
+        array(
             'label' => 'Show Taxonomies',
             'instructions' => 'Shows taxonomy terms on the single view.',
             'name'         => 'show_tax_on_single_view',
@@ -105,6 +149,14 @@ add_filter( 'acf/post_type/registration_args', function( $args, $post_type ) {
     }
     else {
         $args['show_summary_on_single_view'] = true;
+    }
+
+    if ( isset( $post_type['show_toc_on_single_view'] ) ) {
+        $args['show_toc_on_single_view'] = $post_type['show_toc_on_single_view'];
+    }
+
+    if ( isset( $post_type['number_headings'] ) ) {
+        $args['number_headings'] = $post_type['number_headings'];
     }
 
     return $args;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -375,6 +375,9 @@ function hale_get_ordered_content($content, $numbered_headings) {
 	foreach ($index as $content_item) {
 		$list_of_headings .= '<li><a id="anchor-for-'.$content_item[1].'" class="govuk-link" href="#'.$content_item[1].'">'.$content_item[0].'</a></li>';
 	}
+
+	if ($list_of_headings == "") return ""; // If there are no matched headings, then there is no table of contents to shew
+
 	$toc = "<div id='table-of-contents' class='hale-table-of-contents'>
 			<h2 class='govuk-heading-s govuk-!-margin-bottom-2 hale-toc-heading' id='table-of-contents-heading'>".__("Table of contents","hale")."</h2>
 			<ol class='govuk-list $list_class'>$list_of_headings</ol>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -325,11 +325,9 @@ function hale_index( $index_or_content, $ordered = true) {
 		return;
 	}
 
-	$ul = "ul";
 	$list_class = "";
 	// if it is ordered, the index uses an ordered list and the number is displayed
 	if ($ordered) {
-		$ul = "ol";
 		$list_class = "govuk-list--number";
 	}
 
@@ -356,7 +354,7 @@ function hale_index( $index_or_content, $ordered = true) {
 	foreach ($index as $content_item) {
 		$list_of_headings .= '<li><a id="anchor-for-'.$content_item[1].'" class="govuk-link" href="#'.$content_item[1].'">'.$content_item[0].'</a></li>';
 	}
-	$toc = "<div id='table-of-contents'><$ul class='govuk-list $list_class'>$list_of_headings</$ul></div>";
+	$toc = "<div id='table-of-contents' class='hale-table-of-contents'><ol class='govuk-list $list_class'>$list_of_headings</ol></div>";
 
 	if ($index_or_content == "content") echo $changed_content;
 	if ($index_or_content == "index") echo $toc;

--- a/single.php
+++ b/single.php
@@ -13,17 +13,16 @@
 
 get_header();
 ?>
-	<div id="toc" class="govuk-grid-column-one-third">
 	<?php
 	    $show_toc_on_single_view = hale_get_acf_field_status('show_toc_on_single_view');
 	    $number_headings = hale_get_acf_field_status('number_headings');
 
 		// Gets the Table of Contents for the page
 		if (function_exists('hale_table_of_contents') && $show_toc_on_single_view) {
-			echo hale_table_of_contents($number_headings);
+			$toc = hale_table_of_contents($number_headings);
+			echo "<div id='toc' class='govuk-grid-column-one-third'>$toc</div>";
 		}
 		?>
-	</div>
 	<div id="primary" class="govuk-grid-column-two-thirds">
 		<div class="single">
 			<?php

--- a/single.php
+++ b/single.php
@@ -13,7 +13,17 @@
 
 get_header();
 ?>
+	<div id="toc" class="govuk-grid-column-one-third">
+	<?php
+	    $show_toc_on_single_view = hale_get_acf_field_status('show_toc_on_single_view');
+	    $number_headings = hale_get_acf_field_status('number_headings');
 
+		// Gets the Table of Contents for the page
+		if (function_exists('hale_index') && $show_toc_on_single_view) {
+			hale_index("index", $number_headings);
+		}
+		?>
+	</div>
 	<div id="primary" class="govuk-grid-column-two-thirds">
 		<div class="single">
 			<?php

--- a/single.php
+++ b/single.php
@@ -19,8 +19,8 @@ get_header();
 	    $number_headings = hale_get_acf_field_status('number_headings');
 
 		// Gets the Table of Contents for the page
-		if (function_exists('hale_index') && $show_toc_on_single_view) {
-			hale_index("index", $number_headings);
+		if (function_exists('hale_table_of_contents') && $show_toc_on_single_view) {
+			echo hale_table_of_contents($number_headings);
 		}
 		?>
 	</div>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.16.4
+Version: 4.17.0
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice

--- a/template-parts/flexible-cpts/single.php
+++ b/template-parts/flexible-cpts/single.php
@@ -58,9 +58,8 @@
 
     <div class="flexible-post-type-content">
         <?php
-        $number_headings = hale_get_acf_field_status('number_headings');
-        if (function_exists('hale_index')) {
-            hale_index("content", $number_headings);
+        if (function_exists('hale_clean_bad_content')) {
+            hale_clean_bad_content(true);
         }
         ?>
     </div><!-- .article-content -->

--- a/template-parts/flexible-cpts/single.php
+++ b/template-parts/flexible-cpts/single.php
@@ -44,7 +44,7 @@
         if($show_summary){
 
             $summary = get_field('post_summary');
-            
+
             if(!empty($summary)){ ?>
             <div class="intro">
                 <?php echo wpautop($summary); ?>
@@ -58,8 +58,9 @@
 
     <div class="flexible-post-type-content">
         <?php
-        if (function_exists('hale_clean_bad_content')) {
-            hale_clean_bad_content(true);
+        $number_headings = hale_get_acf_field_status('number_headings');
+        if (function_exists('hale_index')) {
+            hale_index("content", $number_headings);
         }
         ?>
     </div><!-- .article-content -->


### PR DESCRIPTION
## What does this pull request do?

Adds two things to ACF Single Custom Posts:
- A table of contents auto-generated from the H2 tags on the page, 
  - Adds IDs to the H2 tags so they can be linked to
- Adds numbers to the front of the H2s

Both things are independently configurable and are off by default

## What is the new Hale version number?

4.17.0

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

