### PR TITLE
Remove latest news [WiP]

### DIFF
--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -63,10 +63,6 @@ function hale_allowed_block_types( $allowed_blocks ) {
             'mojblocks/auto-item-list'
         );
 
-        if (post_type_exists('news')) {
-            $allowed_blocks[] = 'mojblocks/latest-news';
-        }
-
         if( current_user_can('administrator') ) {
             $allowed_blocks[] = 'mojblocks/laa-chatbot';
         }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.20.0
+Version: 4.20.1
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

This removes the Latest News block from the allowed block list.  Existing Latest News blocks will not be affected

## What is the new Hale version number?

4.20.1

## Is the change available on the Dev or Demo environments?

Demo

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

