### PR TITLE
Sticky table of contents

### DIFF
--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -16,8 +16,13 @@ $govuk-font-family: 'PT Sans', sans-serif;
 
 
   body {
-    //the full width cover images go slightly off the pagem this is the easiest fix.
-    overflow-x: hidden;
+    // The full width cover images go slightly off the page, this is the easiest fix.
+    // Also deals with the highlight/shaded blocks (e.g. CTA, highlighted list)
+    // The shading for these have (need) widths of over 100vw which leads to undesirable horizontal scrolling
+    // No content is outside of the page area, just highlighting.
+    // This prevents this from being an issue by preventing horizontal scroll
+    // Overflow hidden breaks position sticky so we use clip
+    overflow-x: clip;
   }
   .hale-search-header + div {
 		margin-top: 30px;

--- a/assets/scss/moj-blocks-general.scss
+++ b/assets/scss/moj-blocks-general.scss
@@ -1,11 +1,3 @@
-.hale-page {
-  // Deals with the Hero and the highlight/shaded blocks (e.g. CTA, highlighted list)
-  // The shading for these have (need) widths of over 100vw which leads to undesirable horizontal scrolling
-  // No content is outside of the page area, just highlighting.
-  // This prevents this from being an issue by preventing horizontal scroll
-  overflow-x: hidden;
-}
-
 .govuk-main-wrapper {
   p:not([class]), p[class=""],
   p.is-style-default,

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -461,6 +461,10 @@
     position: sticky;
     top: 2rem;
   }
+
+  .hale-jump-link {
+    display: none;
+  }
 }
 
 .hale-table-of-contents {

--- a/assets/scss/nav.scss
+++ b/assets/scss/nav.scss
@@ -456,7 +456,18 @@
 
 // Table of contents styling
 
+@include govuk-media-query($from: tablet) {
+  #toc {
+    position: sticky;
+    top: 2rem;
+  }
+}
+
 .hale-table-of-contents {
+  @include govuk-media-query($from: tablet) {
+    max-height: 100vh;
+    overflow-y: scroll;
+  }
   @include govuk-media-query($from: desktop) {
     padding: 0.5rem 0.5rem 1.1rem 0rem;
     ol {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -348,6 +348,17 @@ function hale_get_ordered_content($content, $numbered_headings) {
 		$id = ++$count."-$id"; //$count is incremented & added to ID (this ensures no duplicates)
 		$index[] = ["title"=>$title,"id"=>$id];
 		if ($numbered_headings) $tag->prepend($count.". "); //adds the index number before the title if $ordered set
+
+		//Jump to top link
+		$jump_link = $dom->createElement("a",__("Back to top","hale"));
+		$jump_link->setAttribute('class', 'govuk-link');
+		$jump_link->setAttribute('href', '#table-of-contents-heading'); //link to the table of contents title
+		$tag_suffix = $dom->createElement("span"," (");
+		$tag_suffix->setAttribute('class', 'hale-jump-link govuk-!-font-size-19');
+		$tag_suffix->appendChild($jump_link);
+		$tag_suffix->append(")");
+
+		$tag->appendChild($tag_suffix);
 		$tag->setAttribute('id', $id);
 	}
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.20.1
+Version: 4.20.2
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Makes the table of contents for CPTs sticky:
- The code for the former horizontal scroll issue has had to be altered slightly, tested and seems okay.
- Only sticky on desktop displays.
- Tables of contents which are longer than the page height get their own y-axis scroll.

Added a jump to top link for mobile displays

## What is the new Hale version number?

4.20.2

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [x] Checked on Firefox
- [x] Checked on Chrome

## Notes

