### PR TITLE
Suppress PHP errors

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -336,6 +336,9 @@ add_filter( 'the_content', 'hale_filter_add_index_for_h2_elements', 1 );
 
 function hale_get_ordered_content($content, $numbered_headings) {
 	$index = [];
+	if (empty($content)) {
+        return ["index" => $index, "content" => $content];
+    }
 	$count = 0; //index number
 	$dom = new DOMDocument();
 	libxml_use_internal_errors(true);

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -346,7 +346,8 @@ function hale_get_ordered_content($content, $numbered_headings) {
 		return array("index"=>$index,"content"=>$content);
 	}
 	libxml_clear_errors();
-	$tags = $dom->getElementsByTagName("h2");
+	$xpath = new DOMXPath($dom);
+	$tags = $xpath->query('//h2');
 	foreach($tags as $tag) {
 		$title = $tag->nodeValue;
 		$id = preg_replace('/[^a-zA-Z0-9]/', '', remove_accents($title));

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -337,10 +337,12 @@ add_filter( 'the_content', 'hale_filter_add_index_for_h2_elements', 1 );
 function hale_get_ordered_content($content, $numbered_headings) {
 	$index = [];
 	$count = 0; //index number
-	$dom = new DomDocument();
+	$dom = new DOMDocument();
+	libxml_use_internal_errors(true);
 	if (!$dom->loadHtml('<?xml encoding="UTF-8">'.$content)) {
 		return array("index"=>$index,"content"=>$content);
 	}
+	libxml_clear_errors();
 	$tags = $dom->getElementsByTagName("h2");
 	foreach($tags as $tag) {
 		$title = $tag->nodeValue;

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -337,8 +337,8 @@ add_filter( 'the_content', 'hale_filter_add_index_for_h2_elements', 1 );
 function hale_get_ordered_content($content, $numbered_headings) {
 	$index = [];
 	if (empty($content)) {
-        return ["index" => $index, "content" => $content];
-    }
+		return ["index" => $index, "content" => $content];
+	}
 	$count = 0; //index number
 	$dom = new DOMDocument();
 	libxml_use_internal_errors(true);

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.20.4
+Version: 4.20.5
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Errors were being thrown when creating the table of contents.  After reading up about the errors online, it seems that the answer is to ignore them.  This PR suppresses the errors in this particular area of code, which seems to otherwise be working.  

[The information online is from here](https://ourcodeworld.com/articles/read/1375/how-to-solve-php-7-exception-warning-domdocument-loadhtml-tag-figure-nav-section-invalid).

## What is the new Hale version number?

4.20.5

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

