### PR TITLE
Remove callback function as editors dont have access to colours

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -221,6 +221,8 @@ function hale_customize_register( $wp_customize ) {
 	 * -----------------------------------------------------------
 	*/
 
+	
+
 	$wp_customize->add_setting('print_logo');
 	$wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'print_logo', array(
 		'label' => 'Logo when printing',
@@ -234,15 +236,7 @@ function hale_customize_register( $wp_customize ) {
 			'placeholder' => __( 'No print logo selected' ),
 			'frame_title' => __( 'Select print logo' ),
 			'frame_button' => __( 'Choose print logo' ),
-		),
-		'active_callback' => function () use ( $wp_customize ) {
-			return (
-				!in_array(
-					strtoupper($wp_customize->get_setting( 'header-bg' )->value()),
-					["#FFFFFF","#FFF"]
-				)
-			);
-		}
+		)
 	)));
 
 	/*

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -221,8 +221,6 @@ function hale_customize_register( $wp_customize ) {
 	 * -----------------------------------------------------------
 	*/
 
-	
-
 	$wp_customize->add_setting('print_logo');
 	$wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'print_logo', array(
 		'label' => 'Logo when printing',


### PR DESCRIPTION
## What does this pull request do?

Fix fatal error  for site editors - Remove callback function as editors dont have access to colours

## What is the new Hale version number?

TBC

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [ ] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [ ] Checked on Chrome

## Notes

