### PR TITLE
Footer social link focus bug fix

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -1173,12 +1173,19 @@ body.hale-colours-variable {
 			}
 		}
 
-		.widget_social_widget .hale-social-link:focus {
-			box-shadow:
-				-4px 0 var(--footer-link-focus-background),
-				4px 0 var(--footer-link-focus-background),
-				-4px 4px var(--footer-link-focus-shadow),
-				4px 4px var(--footer-link-focus-shadow);
+		.widget_social_widget .hale-social-link {
+
+			&:hover {
+				box-shadow: 0 4px var(--footer-link);
+			}
+
+			&:focus {
+				box-shadow:
+					-4px 0 var(--footer-link-focus-background),
+					4px 0 var(--footer-link-focus-background),
+					-4px 4px var(--footer-link-focus-shadow),
+					4px 4px var(--footer-link-focus-shadow);
+			}
 		}
 	}
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.5
+Version: 4.21.6
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.3
+Version: 4.21.5
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Adds a missing colour to the CSS file - hover underline for social widgets.  Using the link colour so no new colour setting needed.  

## What is the new Hale version number?

4.21.5

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

