### PR TITLE
Remove latest news from authorised blocks

### DIFF
--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -113,10 +113,6 @@ function hale_get_allowed_blocks(){
         'mojblocks/auto-item-list'
     );
 
-    if (post_type_exists('news')) {
-        $allowed_blocks[] = 'mojblocks/latest-news';
-    }
-
     if( current_user_can('administrator') ) {
         $allowed_blocks[] = 'mojblocks/laa-chatbot';
     }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.6
+Version: 4.21.7
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

This PR prevents new Latest News blocks from being added, the Item List block should be used instead.

## What is the new Hale version number?

4.21.7

## Is the change available on the Dev or Demo environments?

Dev

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

