### PR TITLE
Changed blog social icon class name

### DIFF
--- a/assets/scss/icons.scss
+++ b/assets/scss/icons.scss
@@ -1,7 +1,7 @@
 @import "fontawesome/scss/fontawesome.scss";
 @import "fontawesome/scss/brands.scss";
 
-.blog {
+.blog-icon {
   @extend %fa-icon;
   @extend .fab;
 

--- a/inc/widgets/social-widget.php
+++ b/inc/widgets/social-widget.php
@@ -20,7 +20,7 @@ class social_widget extends WP_Widget {
             echo $args['before_title'] . $title . $args['after_title'];
 
         if ( ! empty( $instance['blog_url'] ) ){
-            echo '<a class="govuk-footer__link hale-social-link" href="' . $instance['blog_url']  . '"><span class="govuk-visually-hidden">Blog</span><i class="blog ' . $harmonized_icons . '" aria-hidden="true"></i></a>';
+            echo '<a class="govuk-footer__link hale-social-link" href="' . $instance['blog_url']  . '"><span class="govuk-visually-hidden">Blog</span><i class="blog-icon ' . $harmonized_icons . '" aria-hidden="true"></i></a>';
         }
 
         if ( ! empty( $instance['facebook_url'] ) ){

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.8
+Version: 4.21.9
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Changes the blog icon class name to avoid class name clash with default WordPress class

## What is the new Hale version number?

4.21.9

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

