### PR TITLE
Cookie banner and page colours

### DIFF
--- a/assets/scss/brandings-cookies.scss
+++ b/assets/scss/brandings-cookies.scss
@@ -1,5 +1,49 @@
-*{
-	//cookie banner styling
+//cookie banner styling
+
+#save-cookies-button {
+	background-color: var(--cookie-button-bg);
+	color: var(--cookie-button-text);
+	-webkit-text-fill-color: var(--cookie-button-text);
+
+	&:hover {
+		background-color: var(--cookie-button-hover-bg);
+		color: var(--cookie-button-hover-text);
+		-webkit-text-fill-color: var(--cookie-button-hover-text);
+	}
+
+	&:focus:hover,&:active,&:focus:not(:hover) {
+		background-color: var(--cookie-button-focus-bg);
+		color: var(--cookie-button-focus-text);
+		-webkit-text-fill-color: var(--cookie-button-focus-text);
+	}
+}
+
+#cookie-compliance-banner {
+	button {
+		@extend #save-cookies-button;
+	}
+	a {
+		color: var(--link);
+		-webkit-text-fill-color: var(--link);
+
+		&:hover {
+			color: var(--link-hover);
+			-webkit-text-fill-color: var(--link-hover);
+		}
+
+		&:focus {
+			color: var(--link-focus);
+			-webkit-text-fill-color: var(--link-focus);
+			background-color: var(--link-focus-background);
+			border: none;
+			outline: 4px solid transparent;
+			box-shadow: 0 -2px var(--link-focus-background), 0 4px var(--link-focus-shadow);
+		}
+	}
+}
+* {
+
+
 	#ccfw-page-banner {
 		.ccfw-banner__button:not(.ccfw-banner__button--close) {
 			background-color: var(--cookie-button-bg);

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.9
+Version: 4.21.10
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Adds the styles for the new cookie banner to Hale - where they will sit harmlessly until the new cookie banner solution is implemented.  
- New banner's button colours
- New banner's link colours
- New settings page button colours

## What is the new Hale version number?

4.21.10

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

