### PR TITLE
Cookie link colour

### DIFF
--- a/assets/scss/brandings-cookies.scss
+++ b/assets/scss/brandings-cookies.scss
@@ -41,6 +41,28 @@
 		}
 	}
 }
+
+#cookie-settings-page {
+	a.cookie-link {
+		color: var(--link);
+		-webkit-text-fill-color: var(--link);
+
+		&:hover {
+			color: var(--link-hover);
+			-webkit-text-fill-color: var(--link-hover);
+		}
+
+		&:focus {
+			color: var(--link-focus);
+			-webkit-text-fill-color: var(--link-focus);
+			background-color: var(--link-focus-background);
+			border: none;
+			outline: 4px solid transparent;
+			box-shadow: 0 -2px var(--link-focus-background), 0 4px var(--link-focus-shadow);
+		}
+	}
+}
+
 * {
 
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.10
+Version: 4.21.11
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Applies the correct colour to links on the new cookie page
(Only one link - the one to google)

## What is the new Hale version number?

4.21.11

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

