### PR TITLE
Ticket taylor

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -1070,32 +1070,8 @@ body.hale-colours-customised {
 
 	.hale-search-header,
 	.page-header-section {
-
-		position: relative;
-		padding: 0.2em 0;
-		margin-bottom: 2rem;
-
-		&:before {
-			@extend .hale-shaded; // gets the shading colour
-			position: absolute;
-			content: "";
-			left: 50%;
-			width: 200vw;
-			height: calc(100% + 0.6em);
-			z-index: -1;
-			display: block;
-			overflow: visible;
-			transform: translate(-50%, -0.3em);
-
-			@media (hover: none) and (pointer: coarse) {
-				display: none;
-			}
-		}
-
-		>* {
-			position: relative;
-			top: 1rem;
-		}
+		background-color: var(--title-shading);
+		box-shadow: 0vw 0px 0 15px var(--title-shading), 50vw 0px 0 15px var(--title-shading), -50vw 0px 0 15px var(--title-shading);
 	}
 
 	/* Category Navigation */
@@ -1113,13 +1089,6 @@ body.hale-colours-customised {
 
 	&.page-body-colour {
 		background-color: var(--title-shading);
-
-		.hale-search-header,
-		.page-header-section {
-			&:before {
-				content: none;
-			}
-		}
 	}
 
 	.gem-c-pagination__item {

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -1071,7 +1071,14 @@ body.hale-colours-customised {
 	.hale-search-header,
 	.page-header-section {
 		background-color: var(--title-shading);
-		box-shadow: 0vw 0px 0 15px var(--title-shading), 50vw 0px 0 15px var(--title-shading), -50vw 0px 0 15px var(--title-shading);
+		box-shadow: 0 0 0 15px var(--title-shading),
+					300px 0px 0 15px var(--title-shading), -300px 0px 0 15px var(--title-shading),
+					600px 0px 0 15px var(--title-shading), -600px 0px 0 15px var(--title-shading),
+					900px 0px 0 15px var(--title-shading), -900px 0px 0 15px var(--title-shading),
+					1200px 0px 0 15px var(--title-shading), -1200px 0px 0 15px var(--title-shading),
+					1500px 0px 0 15px var(--title-shading), -1500px 0px 0 15px var(--title-shading),
+					1800px 0px 0 15px var(--title-shading), -1800px 0px 0 15px var(--title-shading),
+					2100px 0px 0 15px var(--title-shading), -2100px 0px 0 15px var(--title-shading);
 	}
 
 	/* Category Navigation */

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.12
+Version: 4.21.13
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Completely re-does the title shading code as the previous approach interferes with the Ticket Taylor code.  

The new approach uses box shadows - which is a bit more elegant.  As we cannot z-index box shadows, it might cover up other things - but I don't think we ever had a situation where the shading goes beneath something else.  

This only affects normal page and search page titles.

## What is the new Hale version number?

4.21.13

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

