### PR TITLE
Aria labelledby

### DIFF
--- a/assets/js/accordion-auto-expand.js
+++ b/assets/js/accordion-auto-expand.js
@@ -15,8 +15,6 @@
 				// Set the Aria controls to be the same as the (new) content ID
 				// This was the only thing being incremented by PHP, but was still insufficient for many accordions per page
 				haleAllAccordionHeadings[i].closest(".govuk-accordion__section-button").setAttribute("aria-controls", "hale-accordion-content-" + (i+1));
-				// Set the content Aria label to the (new) heading ID
-				haleAllAccordionContentArray[i].setAttribute("aria-labelledby", "hale-accordion-heading-" + (i+1));
 			}
 		}
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.13
+Version: 4.21.14
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Removes the JS which adds `aria-labelledby` to accordion sections

## What is the new Hale version number?

3.21.14

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

