### PR TITLE
Added CSS content to colour error emails

### DIFF
--- a/inc/colour-email-warning.php
+++ b/inc/colour-email-warning.php
@@ -1,6 +1,6 @@
 <?php
 
-function emailWarning($unset_colours,$custom_colours_found,$max,$location,) {
+function emailWarning($unset_colours,$custom_colours_found,$max,$location,$CSS_string = "") {
 	/**
 	 * $unset_colours [array] colour IDs which weren't set
 	 * $custom_colours_found [int] number of colours set
@@ -55,6 +55,10 @@ function emailWarning($unset_colours,$custom_colours_found,$max,$location,) {
 			$message .= "## Other info\r\n";
 			$message .= "This message was triggered from `$location`.\r\n\r\n";
 			$message .= "URI: `$uri`.\r\n\r\n";
+			if ($location == "colours.php") {
+				$CSS_length = strlen($CSS_string);
+				$message .= "Analyzed CSS file contents [length: $CSS_length chars] (this is the CSS which would have been searched causing the error being noticed): \r\n $CSS_string \r\n\r\n";
+			}
 			wp_mail($email, $subject, $message);
 		}
 	}

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -485,7 +485,7 @@
 				 * This next bit emails warnings about unset colours
 				 */
 				require_once get_template_directory() . '/inc/colour-email-warning.php';
-				emailWarning($missing_colour_array,$found_colour_count,$i,"colours.php");
+				emailWarning($missing_colour_array,$found_colour_count,$i,"colours.php",$CSS_string);
 			} else {
 				//if there are no missing colours, nothing needs to be done.
 				//but we still touch the file so the surrounding if statement is not triggered and we don't have to do the get_file_contents each time

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.13
+Version: 4.21.14
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Adds the CSS file contents to colour error emails in order to facilitate the debugging of these errors.  

## What is the new Hale version number?

3.21.14

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [ ] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [ ] Checked on Chrome

## Notes

