### PR TITLE
Topnav errors & mobile errors

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -412,7 +412,7 @@
 							@include hale-heading-link-underline-restrictor($colour: --header-link-focus-highlight);
 						}
 
-						&:hover {
+						&:hover:not(:focus) {
 							color: var(--header-link-hover);
 							border-bottom-color: var(--header-link-hover-border);
 

--- a/assets/scss/hale-styles.scss
+++ b/assets/scss/hale-styles.scss
@@ -21,7 +21,7 @@ html {
 }
 
 .govuk-breadcrumbs {
-  padding: 0.7em 0;
+  padding: 0.7rem 0;
 
   &__list {
     &-item {

--- a/assets/scss/hale-styles.scss
+++ b/assets/scss/hale-styles.scss
@@ -1,3 +1,12 @@
+html {
+  /*
+  * This is a fix for  tiny amounts of horizontal scrolling experienced on mobile.
+  * Overflow hidden might break position sticky so we cannot use that.
+  */
+  overflow-x: clip;
+}
+
+
 .hale-secondary-text {
   color:$govuk-secondary-text-colour;
 }

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -1,6 +1,11 @@
 .hale-header {
   padding-top: 2px; //wee bit of space above the logo
 
+  + div {
+    margin-top: 15px;
+    padding-top: 1.5rem;
+  }
+
   .govuk-header__logotype-text {
 
     @extend .govuk-header__link--homepage;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.21.14
+Version: 4.21.15
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

3 bugs are fixed here:
- On situations with no breadcrumbs, the last item of the main navigation (mobile view only) spills over the bottom of the menu.  This is fixed here by applying margin and padding as needed to items which follow the header if they are divisions.  
- In mobile view, there is some horizontal scrolling happening.  This has been fixed by applying an `overflow-x:clip` property to the `html` tag.  
- The latest Chrome update seems to have removed support for `a:focus:before` in CSS.  It is still supported in Firefox.  I am working on the assumption that this is a bug which will soon be fixed.  In the meantime, I have made our CSS more specific to ensure that hover styles are not applied when focussed (`:hover:focus` isn't working, we don't want `:hover` to be the style).  Luckily `:hover:not(:focus)` is still working.  If this isn't fixed in Chrome soon, we might have to revisit this.  


## What is the new Hale version number?

4.21.15

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [x] Checked on Firefox
- [x] Checked on Chrome

## Notes

