### PR TITLE
Flexible CPT - Breadcrumb parent page setting

### DIFF
--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -165,7 +165,7 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
     );
 
 
-    echo '<div class="acf-label"><label for="acf_post_type-admin_menu_parent" style="font-weight:500;">Breadcrumnb</label></div>';
+    echo '<div class="acf-label"><label for="acf_post_type-admin_menu_parent" style="font-weight:500;">Breadcrumb</label></div>';
     echo '<div class="acf-field acf-field-seperator" data-type="seperator" style="margin-top: 15px;"></div>';
     
 

--- a/inc/acf/admin/post-display-settings.php
+++ b/inc/acf/admin/post-display-settings.php
@@ -164,7 +164,36 @@ add_action('acf/post_type/render_settings_tab/display-settings', function ($acf_
         )
     );
 
-    echo '<div class="acf-label"><label for="acf_post_type-admin_menu_parent" style="font-weight:500;">Page-specific banner</label></div>';
+
+    echo '<div class="acf-label"><label for="acf_post_type-admin_menu_parent" style="font-weight:500;">Breadcrumnb</label></div>';
+    echo '<div class="acf-field acf-field-seperator" data-type="seperator" style="margin-top: 15px;"></div>';
+    
+
+    $front_page_id = get_option('page_on_front');
+    $args = array('post_type' => 'page', 'posts_per_page' => -1);
+    $pages = get_posts($args);
+    $choices = ['' => 'Home'];
+
+    foreach($pages as $page){
+        if($front_page_id != $page->ID && !empty($page->post_title)){
+            $choices[$page->ID] = $page->post_title;
+        }
+    }
+
+    acf_render_field_wrap(
+        array(
+            'label' => 'Parent Page',
+            'instructions' => '',
+            'name'         => 'breadcrumb_parent_page',
+            'prefix'       => 'acf_post_type',
+            'value'        => isset( $acf_post_type['breadcrumb_parent_page'] ) ? $acf_post_type['breadcrumb_parent_page'] : '',
+            'type'         => 'select',
+            'choices' =>  $choices,
+            //'ui' => true,
+        )
+    );
+
+    echo '<br/><div class="acf-label"><label for="acf_post_type-admin_menu_parent" style="font-weight:500;">Page-specific banner</label></div>';
     echo '<div class="acf-field acf-field-seperator" data-type="seperator" style="margin-top: 15px;"></div>';
 
 	acf_render_field_wrap(
@@ -241,6 +270,10 @@ add_filter( 'acf/post_type/registration_args', function( $args, $post_type ) {
 
     if ( isset( $post_type['number_headings'] ) ) {
         $args['number_headings'] = $post_type['number_headings'];
+    }
+
+    if ( isset( $post_type['breadcrumb_parent_page'] ) ) {
+        $args['breadcrumb_parent_page'] = $post_type['breadcrumb_parent_page'];
     }
 
     // Single view banner

--- a/inc/breadcrumbs.php
+++ b/inc/breadcrumbs.php
@@ -245,6 +245,25 @@ function hale_breadcrumb() {
 
 								}
 							}
+
+							if ( is_single()) {
+
+								//Custom set parent page for flexible cpt
+								$parent_page_id = hale_get_post_type_setting('breadcrumb_parent_page'); 
+
+								if(!empty($parent_page_id)){
+									?>
+									<li class="govuk-breadcrumbs__list-item">
+										<a class="govuk-breadcrumbs__link" href="<?php echo esc_url( get_permalink( $parent_page_id ) ); ?>">
+											<?php echo get_the_title( $parent_page_id ); ?>
+										</a>
+									</li>
+									<?php
+									$back_one_level = array( get_permalink( $parent_page_id ), get_the_title( $parent_page_id ) );
+
+								}
+								
+							}
 							if ( ! ( is_archive() || is_category() || is_post_type_archive() || is_search() || is_404() ) ) {
 
 								?>


### PR DESCRIPTION
## What does this pull request do?

Add Flexible CPT parent page for breadcrumb

## What is the new Hale version number?

4.23.0

## Is the change available on the Dev or Demo environments?

Demo

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [x] Checked on Firefox
- [x] Checked on Chrome

## Notes

