### PR TITLE
Hide Subtopic filter - previously just disabled the select

### DIFF
--- a/assets/js/page-listing.js
+++ b/assets/js/page-listing.js
@@ -12,6 +12,7 @@ jQuery(document).ready(function ($) {
       if (termsWithParents.length > 0) {
         populateSubTopics(childClass, termsWithParents);
         $(childClass).prop('disabled', false);
+        $(childClass+'-wrapper').removeClass('govuk-visually-hidden');
       } else {
         resetSubTopics(childClass);
       }
@@ -52,6 +53,7 @@ jQuery(document).ready(function ($) {
     $(childClass).empty();
     $(childClass).append(new Option("Select option", ""));
     $(childClass).prop('disabled', true); // Disable the dropdown by default
+    $(childClass+'-wrapper').addClass('govuk-visually-hidden');
   }
 
   // Attach change event listeners to each parent topic dropdown

--- a/template-parts/flexible-cpts/listing-filters.php
+++ b/template-parts/flexible-cpts/listing-filters.php
@@ -98,6 +98,7 @@ if (!empty($listing_filters) && is_array($listing_filters)) {
 
         if ($has_subtopics) {
             $disabled_subtopics = 'disabled="disabled"';
+            $subtopic_wrapper_classes = 'govuk-visually-hidden';
 
             $sub_topics = [];
 
@@ -110,6 +111,7 @@ if (!empty($listing_filters) && is_array($listing_filters)) {
 
                 if (!empty($sub_topics)) {
                     $disabled_subtopics = '';
+                    $subtopic_wrapper_classes = '';
                 }
             }
 
@@ -123,7 +125,10 @@ if (!empty($listing_filters) && is_array($listing_filters)) {
                 $subfilter_label = "Sub-topic";
             }
 
+
+            $wrapper_id = $child_class_name . '-wrapper';
             
+            echo '<div id="' . $wrapper_id . '"class="' . $subtopic_wrapper_classes . '">';
             echo '<label class="govuk-label" for="' . esc_attr($child_class_name) . '">' . esc_html($subfilter_label) . '</label>';
             echo '<select name="' . esc_attr($subtopic_query_var) . '" id="' . esc_attr($child_class_name) . '" class="govuk-select filter-subtopic" ' . $disabled_subtopics . '>';
             echo '<option value="0"' . selected($selected_sub_topic, 0, false) . '>Select option</option>';
@@ -134,6 +139,7 @@ if (!empty($listing_filters) && is_array($listing_filters)) {
                 echo '</option>';
             }
             echo '</select>';
+            echo '</div>';
         }
     }
 }


### PR DESCRIPTION
## What does this pull request do?

Replace subtopic filter to be hidden until needed

## What is the new Hale version number?

4.24.0

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [x] Checked on Firefox
- [x] Checked on Chrome

## Notes

