### PR TITLE
Add autocomplete filter to listing page - part one

### DIFF
--- a/assets/js/autocomplete-filter.js
+++ b/assets/js/autocomplete-filter.js
@@ -1,24 +1,206 @@
-/* autocomplete filter for listing page */
+/* Simplified autocomplete filter for listing page */
+var taxonomies_with_terms = {};
 
+// Check if the object exists and extract terms
+if (typeof listing_page_object !== 'undefined') {
+    console.log('listing_page_object:', listing_page_object);
+    
+    // Store taxonomy terms
+    Object.entries(listing_page_object.taxonomies).forEach(([taxonomy_name, taxonomy_terms]) => {
+        taxonomies_with_terms[taxonomy_name] = taxonomy_terms;
+    });
+}
 
-const countries = [
-  'France',
-  'Germany',
-  'United Kingdom'
-]
+// Function to update subtopic dropdown when parent term is selected
+function updateSubtopicDropdown(taxonomy_name, parent_term_id, container) {
+    const hasSubtopics = container.getAttribute('data-has-subtopics') === '1';
+    
+    if (!hasSubtopics) return;
+    
+    const childClass = container.getAttribute('data-child-class');
+    const wrapper = document.getElementById(childClass + '-wrapper');
+    const subtopicSelect = document.getElementById(childClass);
+    
+    if (!wrapper || !subtopicSelect) return;
+    
+    // Clear existing options
+    subtopicSelect.innerHTML = '<option value="0">Select option</option>';
+    
+    if (parent_term_id && parent_term_id !== '0') {
+        // Get child terms for the selected parent
+        const childTerms = taxonomies_with_terms[taxonomy_name]
+            .filter(term => term.parent == parent_term_id);
+        
+        if (childTerms.length > 0) {
+            // Show subtopic dropdown and enable it
+            wrapper.classList.remove('govuk-visually-hidden');
+            subtopicSelect.removeAttribute('disabled');
+            
+            // Add child options
+            childTerms.forEach(term => {
+                const option = document.createElement('option');
+                option.value = term.term_id;
+                option.textContent = term.name;
+                subtopicSelect.appendChild(option);
+            });
+        } else {
+            // Hide subtopic dropdown if no children
+            wrapper.classList.add('govuk-visually-hidden');
+            subtopicSelect.setAttribute('disabled', 'disabled');
+        }
+    } else {
+        // Hide subtopic dropdown when no parent selected
+        wrapper.classList.add('govuk-visually-hidden');
+        subtopicSelect.setAttribute('disabled', 'disabled');
+    }
+}
 
 document.addEventListener("DOMContentLoaded", function() {
-    accessibleAutocomplete({
-        element: document.querySelector('#listing-template-autocomplete-container'),
-        id: 'listing-template-autocomplete',
-        name: 'listing-template-autocomplete',
-        displayMenu: 'overlay',
-        placeholder: '',
-        source: countries,
-        showAllValues: true,
-        dropdownArrow: function (config) {
-            return '<svg class="' + config.className + '" style="top: 12px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
-        },
+    // Find all autocomplete containers
+    const containers = document.querySelectorAll('[id^="listing-template-autocomplete-container-"]');
+    
+    containers.forEach(container => {
+        const taxonomy_name = container.getAttribute('data-taxonomy');
+        const selected_name = container.getAttribute('data-selected-name');
+        const selected_value = container.getAttribute('data-selected-value');
+        const exclude_terms = container.getAttribute('data-exclude-terms');
+        const has_subtopics = container.getAttribute('data-has-subtopics') === '1';
+        
+        // Get terms for this taxonomy
+        let taxonomy_terms = taxonomies_with_terms[taxonomy_name] || [];
+        
+        // Filter out excluded terms if needed
+        if (exclude_terms && exclude_terms !== '') {
+            const excludeIds = exclude_terms.split(',').map(id => parseInt(id.trim()));
+            taxonomy_terms = taxonomy_terms.filter(term => !excludeIds.includes(parseInt(term.term_id)));
+        }
+        
+        // For hierarchical taxonomies, only show parent terms in autocomplete
+        let source_terms; // FIXED: Declare variable properly
+        if (has_subtopics) {
+            source_terms = taxonomy_terms
+                .filter(term => term.parent == 0) // Only parent terms
+                .map(term => term.name);
+        } else {
+            source_terms = taxonomy_terms.map(term => term.name);
+        }
+        
+        console.log(`Setting up autocomplete for taxonomy: ${taxonomy_name}`);
+        console.log('Selected value from URL:', selected_value);
+        console.log('Selected name for display:', selected_name);
+        console.log('Available terms:', source_terms);
+        console.log('Has subtopics:', has_subtopics);
+        
+        accessibleAutocomplete({
+            element: container,
+            id: `listing-template-autocomplete-${taxonomy_name}`,
+            name: `listing-template-autocomplete-${taxonomy_name}`,
+            displayMenu: 'overlay',
+            placeholder: '',
+            defaultValue: selected_name || '', // Show selected term on page load (ensure it's not null)
+            source: function (query, populateResults) {
+                const results = source_terms.filter(term => 
+                    term.toLowerCase().includes(query.toLowerCase())
+                );
+                populateResults(results);
+            },
+            showAllValues: true,
+            dropdownArrow: function (config) {
+                return '<svg class="' + config.className + '" style="top: 12px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
+            },
+            onConfirm: (selectedValue) => {
+                updateHiddenInput(selectedValue);
+            }
+        });
+        
+        // Function to update hidden input (shared between onConfirm and form submit)
+        function updateHiddenInput(selectedValue) {
+            console.log('Updating hidden input with value:', selectedValue);
+            
+            // Find the selected term object
+            const selectedTerm = taxonomy_terms.find(term => term.name === selectedValue);
+            
+            if (selectedTerm) {
+                // Update the hidden input with the term ID
+                const hiddenInput = document.getElementById(`listing-template-hidden-input-${taxonomy_name}`);
+                if (hiddenInput) {
+                    hiddenInput.value = selectedTerm.term_id;
+                    console.log(`Updated hidden input for ${taxonomy_name}: ${selectedTerm.term_id}`);
+                    
+                    // Trigger change event for any other scripts that might be listening
+                    hiddenInput.dispatchEvent(new Event('change'));
+                    
+                    // Update subtopic dropdown if this taxonomy has subtopics
+                    if (has_subtopics) {
+                        updateSubtopicDropdown(taxonomy_name, selectedTerm.term_id, container);
+                    }
+                }
+            } else {
+                // Clear the hidden input if no term selected
+                const hiddenInput = document.getElementById(`listing-template-hidden-input-${taxonomy_name}`);
+                if (hiddenInput) {
+                    hiddenInput.value = '';
+                    hiddenInput.dispatchEvent(new Event('change'));
+                    
+                    // Hide subtopic dropdown if this taxonomy has subtopics
+                    if (has_subtopics) {
+                        updateSubtopicDropdown(taxonomy_name, '', container);
+                    }
+                }
+            }
+        }
+        
+        // CRITICAL: Add event listeners to catch form submissions and update hidden input
+        const autocompleteInput = container.querySelector('input[type="text"]');
+        if (autocompleteInput) {
+            // Update hidden input when autocomplete input loses focus
+            autocompleteInput.addEventListener('blur', () => {
+                const currentValue = autocompleteInput.value;
+                if (currentValue && source_terms.includes(currentValue)) {
+                    updateHiddenInput(currentValue);
+                }
+            });
+            
+            // Update hidden input when user presses Enter
+            autocompleteInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault(); // Prevent form submission
+                    const currentValue = autocompleteInput.value;
+                    if (currentValue && source_terms.includes(currentValue)) {
+                        updateHiddenInput(currentValue);
+                    }
+                    // Now submit the form
+                    setTimeout(() => {
+                        const form = autocompleteInput.closest('form');
+                        if (form) form.submit();
+                    }, 100);
+                }
+            });
+        }
+        
+        // CRITICAL: Add form submit handler to ensure hidden input is updated before submission
+        const form = container.closest('form');
+        if (form) {
+            form.addEventListener('submit', (e) => {
+                const autocompleteInput = container.querySelector('input[type="text"]');
+                if (autocompleteInput && autocompleteInput.value) {
+                    const currentValue = autocompleteInput.value;
+                    if (source_terms.includes(currentValue)) {
+                        // Prevent default submission temporarily
+                        e.preventDefault();
+                        
+                        // Update hidden input
+                        updateHiddenInput(currentValue);
+                        
+                        // Submit form after a brief delay to ensure hidden input is updated
+                        setTimeout(() => {
+                            form.submit();
+                        }, 50);
+                    }
+                }
+            });
+        }
+        
+        // Don't initialize subtopics on page load - only show when parent is actively selected
     });
 });
-

--- a/assets/js/autocomplete-filter.js
+++ b/assets/js/autocomplete-filter.js
@@ -1,0 +1,24 @@
+/* autocomplete filter for listing page */
+
+
+const countries = [
+  'France',
+  'Germany',
+  'United Kingdom'
+]
+
+document.addEventListener("DOMContentLoaded", function() {
+    accessibleAutocomplete({
+        element: document.querySelector('#listing-template-autocomplete-container'),
+        id: 'listing-template-autocomplete',
+        name: 'listing-template-autocomplete',
+        displayMenu: 'overlay',
+        placeholder: '',
+        source: countries,
+        showAllValues: true,
+        dropdownArrow: function (config) {
+            return '<svg class="' + config.className + '" style="top: 12px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
+        },
+    });
+});
+

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Hale theme functions and definitions
  *
@@ -22,7 +23,7 @@ require get_template_directory() . '/inc/sanitization-callbacks.php';
  */
 function hale_setup()
 {
-    load_theme_textdomain('hale',get_template_directory() . '/languages');
+    load_theme_textdomain('hale', get_template_directory() . '/languages');
     // Add default posts and comments RSS feed links to head.
     add_theme_support('automatic-feed-links');
 
@@ -172,7 +173,7 @@ function hale_content_width()
 {
     // This variable is intended to be overruled from themes.
     // Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
-	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
     $GLOBALS['content_width'] = apply_filters('hale_content_width', 640);
 }
 
@@ -182,21 +183,23 @@ add_action('after_setup_theme', 'hale_content_width', 0);
  * Enqueue scripts and styles.
  */
 
-function hale_action_customize_save_after( $array ) {
+function hale_action_customize_save_after($array)
+{
     // generate from options on page rather than preview CSS file to avoid editor clash of styles if someone else is previewing at the same time.
 
     clearstatcache();
     $upload_file_path = wp_get_upload_dir()["basedir"];
-    rename ($upload_file_path."/temp-colours.css", $upload_file_path."/custom-colours.css");
+    rename($upload_file_path."/temp-colours.css", $upload_file_path."/custom-colours.css");
 };
 
-add_action( 'customize_save_after', 'hale_action_customize_save_after', 10, 1 );
+add_action('customize_save_after', 'hale_action_customize_save_after', 10, 1);
 
-function hale_scripts() {
+function hale_scripts()
+{
     wp_enqueue_style('hale-style', hale_mix_asset('/css/style.min.css'));
     wp_enqueue_style('hale-custom-branding', hale_mix_asset('/css/custom-branding.min.css'));
-    
-    $t=time();
+
+    $t = time();
 
     if (is_customize_preview()) {
         $css_file_name = "/temp-colours.css?t=$t";
@@ -207,7 +210,7 @@ function hale_scripts() {
 
     if (is_ssl()) {
         //wp_get_upload_dir()["baseurl"] only returns http.
-        $baseURL = str_replace('http://','https://',wp_get_upload_dir()["baseurl"]);
+        $baseURL = str_replace('http://', 'https://', wp_get_upload_dir()["baseurl"]);
         wp_enqueue_style('hale-custom-colours', $baseURL . $css_file_name);
     } else {
         wp_enqueue_style('hale-custom-colours', wp_get_upload_dir()["baseurl"] . $css_file_name);
@@ -219,22 +222,31 @@ function hale_scripts() {
     wp_enqueue_script('hale-combined-scripts', hale_mix_asset('/js/hale-combined-scripts.js'), '', null, true);
 
     // Load Listing template JS
-    if ( is_page_template('page-listing.php') ) {
+    if (is_page_template('page-listing.php')) {
         $script_path = get_template_directory() . '/dist/js/page-listing.js';
         $script_version = file_exists($script_path) ? filemtime($script_path) : false;
         wp_register_script('page-listing', hale_mix_asset('/js/page-listing.js'), array(), $script_version, true);
         wp_enqueue_script('page-listing');
 
-         //used for date picker
-         wp_enqueue_script('moj-frontend', hale_mix_asset('/js/moj-frontend.js'), '', "3.2.0", true);
-         
+        //used for date picker
+        wp_enqueue_script('moj-frontend', hale_mix_asset('/js/moj-frontend.js'), '', "3.2.0", true);
+
     }
 
-    if ( is_page_template('page-hearing-list.php') ) {
-
+    if (is_page_template('page-hearing-list.php') || is_page_template('page-listing.php')) {
         //autocomplete styles and js
         wp_enqueue_style('hale-autocomplete', hale_mix_asset('/css/accessible-autocomplete.min.css'));
         wp_enqueue_script('autocomplete', hale_mix_asset('/js/accessible-autocomplete.min.js'), '', "3.0.1", true);
+
+
+        $script_path = get_template_directory() . '/dist/js/autocomplete-filter.js';
+        $script_version = file_exists($script_path) ? filemtime($script_path) : false;
+        wp_register_script('autocomplete-filter', hale_mix_asset('/js/autocomplete-filter.js'), array(), $script_version, true);
+        wp_enqueue_script('autocomplete-filter');
+    }
+
+    if (is_page_template('page-hearing-list.php')) {
+
 
         //used for date picker
         wp_enqueue_script('moj-frontend', hale_mix_asset('/js/moj-frontend.js'), '', "3.2.0", true);
@@ -250,7 +262,7 @@ function hale_scripts() {
 add_action('wp_enqueue_scripts', 'hale_scripts');
 
 /**
- * Enqueue listing template JS and 
+ * Enqueue listing template JS and
  * localize the script with data
  */
 require get_template_directory() . '/inc/listing-template/localize-script-data.php';
@@ -277,7 +289,7 @@ add_action('wp_print_scripts', 'hale_dequeue_scripts', 100);
 function hale_mix_asset($filename)
 {
     $manifest_path = get_template_directory() . '/dist/mix-manifest.json';
-    
+
     if (!file_exists($manifest_path)) {
         error_log("Mix manifest file does not exist at path: $manifest_path");
         return '';
@@ -393,7 +405,7 @@ require get_template_directory() . '/inc/flexible-cpts.php';
  * ACF additions
  */
 
- // Admin changes
+// Admin changes
 require get_template_directory() . '/inc/acf/admin/settings.php';
 require get_template_directory() . '/inc/acf/admin/post-display-settings.php';
 require get_template_directory() . '/inc/acf/admin/post-block-settings.php';
@@ -488,19 +500,19 @@ require get_template_directory() . '/inc/image-management.php';
 require get_template_directory() . '/inc/uploads.php';
 
 /**
- * Disable archives 
+ * Disable archives
  */
 require get_template_directory() . '/inc/disable-archives.php';
 
 /**
- * Remove default post type 
+ * Remove default post type
  */
 require get_template_directory() . '/inc/remove-default-post-type.php';
 
-function hale_manage_page_templates($post_templates,  $theme, $post, $post_type)
+function hale_manage_page_templates($post_templates, $theme, $post, $post_type)
 {
 
-    if(is_admin()) {
+    if (is_admin()) {
         $screen = get_current_screen();
 
         //Checks if on page edit screen - means all templates show on acf settings
@@ -508,7 +520,7 @@ function hale_manage_page_templates($post_templates,  $theme, $post, $post_type)
 
             //Checks if page templates are being requested
             if ($post_type == 'page') {
-                
+
                 if (!post_type_exists('hearing')) {
                     unset($post_templates['page-hearing-list.php']);
                 }
@@ -519,29 +531,30 @@ function hale_manage_page_templates($post_templates,  $theme, $post, $post_type)
     return $post_templates;
 }
 
-add_filter( 'theme_templates', 'hale_manage_page_templates' , 10, 4);
+add_filter('theme_templates', 'hale_manage_page_templates', 10, 4);
 
-function hale_add_module_tag( $tag, $handle, $src ) {
+function hale_add_module_tag($tag, $handle, $src)
+{
     $modules = ["govuk-frontend"];
-    if ( in_array($handle, $modules) ) {
-        $tag = str_replace( 'src=', 'type="module" src=', $tag );
+    if (in_array($handle, $modules)) {
+        $tag = str_replace('src=', 'type="module" src=', $tag);
     }
     return $tag;
 }
-add_filter( 'script_loader_tag', 'hale_add_module_tag', 10, 3 );
+add_filter('script_loader_tag', 'hale_add_module_tag', 10, 3);
 
 // Remove Yoast `SEO Manager` role
-if ( get_role('wpseo_manager') ) {
-    remove_role( 'wpseo_manager' );
+if (get_role('wpseo_manager')) {
+    remove_role('wpseo_manager');
 }
 
 // Remove Yoast `SEO Editor` role
-if ( get_role('wpseo_editor') ) {
-    remove_role( 'wpseo_editor' );
+if (get_role('wpseo_editor')) {
+    remove_role('wpseo_editor');
 }
 
 //Remove relevanssi throttle as it prevents some documents and pages showing on listing and search pages
-remove_filter( 'relevanssi_query_filter', 'relevanssi_limit_filter' );
+remove_filter('relevanssi_query_filter', 'relevanssi_limit_filter');
 
 /**
  * Add options for lang attribute for footer menu links

--- a/inc/acf/admin/taxonomy-settings.php
+++ b/inc/acf/admin/taxonomy-settings.php
@@ -1,6 +1,38 @@
 <?php
 
+/**
+ * Add autocomplete toggle to the taxonomy settings page
+ *
+ * https://www.advancedcustomfields.com/resources/post-types-and-taxonomies/
+ *
+ */
+add_action('acf/taxonomy/basic_settings', function ($acf_taxonomy) {
+
+    acf_render_field_wrap([
+        'label'        => 'Autocomplete',
+        'instructions' => 'Enable autocomplete on all listing page filters using this taxonomy.',
+        'name'         => 'autocomplete',
+        'key'          => 'autocomplete',
+        'prefix'       => 'acf_taxonomy',
+        'value'        => isset($acf_taxonomy['autocomplete']) ? $acf_taxonomy['autocomplete'] : false,
+        'type'         => 'true_false',
+        'ui'           => 1,
+    ]);
+});
+
+/**
+ * Register the autocomplete toggle for taxonomies
+ */
+add_filter('acf/taxonomy/registration_args', function ($args, $taxonomy) {
+    if (isset($taxonomy['autocomplete'])) {
+        $args['autocomplete'] = (bool) $taxonomy['autocomplete'];
+    }
+
+    return $args;
+}, 10, 2);
+
 //Adds new labels to taxonomy
+//Found in Advanced Settings -> Labels
 add_action('acf/taxonomy/render_settings_tab/labels', function ($acf_taxonomy) {
 
     acf_render_field_wrap(
@@ -12,17 +44,17 @@ add_action('acf/taxonomy/render_settings_tab/labels', function ($acf_taxonomy) {
             'value'        => $acf_taxonomy['labels']['listing_page_filter'],
             'data'         => array(
                 /* translators: %s Singular form of taxonomy name */
-                'label'     => __( '%s', 'acf' ),
+                'label'     => __('%s', 'acf'),
                 'replace'   => 'singular',
             ),
-            'label'        => __( 'Listing Page Filter', 'acf' ),
-            'instructions' => __( 'Displayed on listing page with a taxonomy filter', 'acf' ),
-            'placeholder'  => __( 'Tag', 'acf' ),
+            'label'        => __('Listing Page Filter', 'acf'),
+            'instructions' => __('Displayed on listing page with a taxonomy filter', 'acf'),
+            'placeholder'  => __('Tag', 'acf'),
         ),
         'div',
         'field'
     );
-    
+
     acf_render_field_wrap(
         array(
             'type'         => 'text',
@@ -32,15 +64,14 @@ add_action('acf/taxonomy/render_settings_tab/labels', function ($acf_taxonomy) {
             'value'        => $acf_taxonomy['labels']['listing_page_subfilter'],
             'data'         => array(
                 /* translators: %s Singular form of taxonomy name */
-                'label'     => __( 'Sub %s', 'acf' ),
+                'label'     => __('Sub %s', 'acf'),
                 'replace'   => 'singular',
             ),
-            'label'        => __( 'Listing Page Subfilter', 'acf' ),
-            'instructions' => __( 'Displayed on listing page when a taxonomy filter has sub terms', 'acf' ),
-            'placeholder'  => __( 'Subtag', 'acf' ),
+            'label'        => __('Listing Page Subfilter', 'acf'),
+            'instructions' => __('Displayed on listing page when a taxonomy filter has sub terms', 'acf'),
+            'placeholder'  => __('Subtag', 'acf'),
         ),
         'div',
         'field'
     );
 });
-

--- a/template-parts/flexible-cpts/autocomplete-filter.php
+++ b/template-parts/flexible-cpts/autocomplete-filter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Template part for displaying list autocomplete
+ */
+
+$all_terms = get_terms(array(
+   'taxonomy' => 'learning_types',
+));
+
+$selected_terms = [];
+$selected_terms_qry = get_query_var('learning_types');
+
+if (!empty($selected_terms_qry)) {
+    $selected_terms = explode(",", $selected_terms_qry);
+}
+
+if (!empty($all_terms)) {
+
+    ?>
+<div class="govuk-form-group">
+    <label for="hearing-witness-autocomplete" class="govuk-label">Title</label>
+    <div id="hearing-witness-hint" class="govuk-hint">
+
+    <input
+        type="hidden" id="hearing-witness-multiselect-hidden-input" name="hearing-witness"
+        value="<?php echo $selected_terms_qry; ?>" aria-describedby="hearing-witness-hint"
+    />
+
+    </div>
+
+    <div id="listing-template-autocomplete-container"></div>
+</div>
+    <?php } ?> 

--- a/template-parts/flexible-cpts/autocomplete-filter.php
+++ b/template-parts/flexible-cpts/autocomplete-filter.php
@@ -1,33 +1,98 @@
 <?php
 /**
- * Template part for displaying list autocomplete
+ * Template part for displaying autocomplete filter
+ * Used by page-listing.php as replacement for wp_dropdown_categories
  */
 
-$all_terms = get_terms(array(
-   'taxonomy' => 'learning_types',
-));
+// Get variables from args
+$taxonomy_name = $args['taxonomy-name'];
+$taxonomy = $args['taxonomy'];
+$selected_topic = $args['selected-topic'];
+$has_subtopics = $args['has-subtopics'];
+$child_class_name = $args['child-class-name'];
+$subtopic_query_var = $args['subtopic-query-var'];
+$dropdown_exclude = $args['dropdown-exclude'];
+$selected_term_name = $args['selected-term-name'];
 
-$selected_terms = [];
-$selected_terms_qry = get_query_var('learning_types');
 
-if (!empty($selected_terms_qry)) {
-    $selected_terms = explode(",", $selected_terms_qry);
-}
 
-if (!empty($all_terms)) {
+// Create parent class name for label consistency (matches original dropdown structure)
+$parent_class_name = str_replace(' ', '-', $taxonomy->name . '-filter-topic');
+?>
 
-    ?>
-<div class="govuk-form-group">
-    <label for="hearing-witness-autocomplete" class="govuk-label">Title</label>
-    <div id="hearing-witness-hint" class="govuk-hint">
-
+<!-- Autocomplete Container -->
+<div id="autocomplete-hint-<?php echo esc_attr($taxonomy_name); ?>" class="govuk-hint">
     <input
-        type="hidden" id="hearing-witness-multiselect-hidden-input" name="hearing-witness"
-        value="<?php echo $selected_terms_qry; ?>" aria-describedby="hearing-witness-hint"
+        type="hidden"
+        id="listing-template-hidden-input-<?php echo esc_attr($taxonomy_name); ?>" 
+        name="<?php echo esc_attr($taxonomy->query_var); ?>"
+        value="<?php echo esc_attr($selected_topic); ?>" 
+        aria-describedby="autocomplete-hint-<?php echo esc_attr($taxonomy_name); ?>"
     />
-
-    </div>
-
-    <div id="listing-template-autocomplete-container"></div>
 </div>
-    <?php } ?> 
+
+<div 
+    id="listing-template-autocomplete-container-<?php echo esc_attr($taxonomy_name); ?>" 
+    data-taxonomy="<?php echo esc_attr($taxonomy_name); ?>"
+    data-selected-value="<?php echo esc_attr($selected_topic); ?>"
+    data-selected-name="<?php echo esc_attr($selected_term_name); ?>"
+    data-query-var="<?php echo esc_attr($taxonomy->query_var); ?>"
+    data-has-subtopics="<?php echo $has_subtopics ? '1' : '0'; ?>"
+    data-child-class="<?php echo esc_attr($child_class_name); ?>"
+    data-subtopic-query-var="<?php echo esc_attr($subtopic_query_var); ?>"
+    data-exclude-terms="<?php echo esc_attr(is_array($dropdown_exclude) ? implode(',', $dropdown_exclude) : ''); ?>"
+></div>
+
+<?php if ($has_subtopics): ?>
+    <?php
+    // Get current selected subtopic
+    $selected_sub_topic = get_query_var($subtopic_query_var);
+
+    $disabled_subtopics = 'disabled="disabled"';
+    $subtopic_wrapper_classes = 'govuk-visually-hidden';
+
+    $sub_topics = [];
+
+    if (is_numeric($selected_topic) && $selected_topic > 0) {
+        $sub_topics = get_terms(array(
+            'taxonomy' => $taxonomy_name,
+            'parent' => $selected_topic,
+            'hide_empty' => false,
+        ));
+
+        if (!empty($sub_topics)) {
+            $disabled_subtopics = '';
+            $subtopic_wrapper_classes = '';
+        }
+    }
+
+    // Get subtopic label (same logic as main filter)
+    $subfilter_label = 'Sub ' . $taxonomy->labels->singular_name;
+    if (isset($taxonomy->labels->listing_page_subfilter) && !empty($taxonomy->labels->listing_page_subfilter)) {
+        $subfilter_label = $taxonomy->labels->listing_page_subfilter;
+    }
+    if ($taxonomy_name == "category") {
+        $subfilter_label = "Sub-topic";
+    }
+
+    $wrapper_id = $child_class_name . '-wrapper';
+    ?>
+    
+    <div id="<?php echo esc_attr($wrapper_id); ?>" class="<?php echo esc_attr($subtopic_wrapper_classes); ?>">
+        <label class="govuk-label" for="<?php echo esc_attr($child_class_name); ?>">
+            <?php echo esc_html($subfilter_label); ?>
+        </label>
+        <select name="<?php echo esc_attr($subtopic_query_var); ?>" 
+                id="<?php echo esc_attr($child_class_name); ?>" 
+                class="govuk-select filter-subtopic" 
+                <?php echo $disabled_subtopics; ?>>
+            <option value="0" <?php selected($selected_sub_topic, 0); ?>>Select option</option>
+            <?php foreach ($sub_topics as $sub_topic): ?>
+                <option value="<?php echo esc_attr($sub_topic->term_id); ?>" 
+                        <?php selected($selected_sub_topic, $sub_topic->term_id); ?>>
+                    <?php echo esc_html($sub_topic->name); ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+<?php endif; ?>

--- a/template-parts/flexible-cpts/listing-filters.php
+++ b/template-parts/flexible-cpts/listing-filters.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ACF data generated side filter component
  * Used by page-listing.php
@@ -9,32 +10,42 @@ $listing_filters = $args['listing-filters'];
 if (!empty($listing_filters) && is_array($listing_filters)) {
     foreach ($listing_filters as $filter) {
 
+        // Handle different filter types
         if (taxonomy_exists($filter)) {
-            get_template_part('template-parts/flexible-cpts/taxonomy-filter', false, ['taxonomy-name' => $filter ]);
-        }
-        else if($filter == 'published-date'){
-            get_template_part('template-parts/flexible-cpts/date-filter', false, ['name' => "date_published", "label" => ""]);
-        }
-        else if(str_starts_with($filter, "meta-")){
-            //METAFIELDS
-            $field_name = str_replace("meta-", "", $filter);
-            $listing_post_type = get_post_meta(get_the_ID(), 'listing_post_type', true);
-            $label = "";
 
+            get_template_part('template-parts/flexible-cpts/taxonomy-filter', false, [
+                           'taxonomy-name' => $filter
+            ]);
+
+        } elseif ($filter === 'published-date') {
+            // Handle published date filter
+            get_template_part('template-parts/flexible-cpts/date-filter', false, [
+                'name' => 'date_published',
+                'label' => ''
+            ]);
+        } elseif (str_starts_with($filter, 'meta-')) {
+            // Handle meta field filters
+            $field_name = str_replace('meta-', '', $filter);
+            $listing_post_type = get_post_meta(get_the_ID(), 'listing_post_type', true);
+
+            // Get field label
+            $label = '';
             $fields = hale_get_post_type_date_fields($listing_post_type);
 
             if (!empty($fields)) {
-                foreach($fields as $field){
-                            
-                    if($field['name'] == $field_name){
+                foreach ($fields as $field) {
+                    if ($field['name'] === $field_name) {
                         $label = $field['label'];
                         break;
                     }
                 }
             }
 
-            get_template_part('template-parts/flexible-cpts/date-filter', false, ['name' => $field_name, "label" => $label]);
-            
+            get_template_part('template-parts/flexible-cpts/date-filter', false, [
+                'name' => $field_name,
+                'label' => $label
+            ]);
         }
+
     }
 }

--- a/template-parts/flexible-cpts/taxonomy-filter.php
+++ b/template-parts/flexible-cpts/taxonomy-filter.php
@@ -1,12 +1,11 @@
 <?php
+
 /**
  * ACF data generated side filter component
  * Used by page-listing.php
- *
-*/
+ */
 
 $taxonomy_name = $args['taxonomy-name'];
-
 $taxonomy = get_taxonomy($taxonomy_name);
 
 $parent_class_name = str_replace(' ', '-', $taxonomy->name . '-filter-topic');
@@ -15,7 +14,7 @@ $child_class_name = str_replace(' ', '-', $taxonomy->name . '-filter-subtopic');
 // Get the selected parent topic
 $selected_topic = get_query_var($taxonomy->query_var);
 
-// Use a unique query var for each genre_subtopic
+// Use a unique query var for each subtopic
 $subtopic_query_var = $taxonomy->query_var . '_subtopic';
 $selected_sub_topic = get_query_var($subtopic_query_var);
 
@@ -25,9 +24,6 @@ $restrict_field = 'restrict_by_' . $taxonomy_name;
 // ACF 'restrict_by_*' custom field is generated via code
 // https://github.com/ministryofjustice/hale/blob/6d5ca3c9c6ddbcf27b23857223a54bcdf5778def/inc/flexible-cpts.php
 $restrict_terms = get_field($restrict_field);
-
-// todo: check if tax slug is restricted
-//$taxonomy_term_ids = get_taxonomy_term_ids($restrict_taxonomies_array);
 
 if (empty($restrict_terms)) {
     $dropdown_exclude = "";
@@ -41,40 +37,12 @@ if (is_array($restrict_terms) && !empty($restrict_terms)) {
     ]);
 
     if (!empty($exclude_terms)) {
-        // For all the terms left after excluding the restricted ones
-        // get their ids into an array
-        $dropdown_exclude = array_map(function($term) {
+        $dropdown_exclude = array_map(function ($term) {
             return $term->term_id;
         }, $exclude_terms);
     }
 }
 
-$dropdown_args = [
-    "name" => $taxonomy->query_var,
-    "id" => $parent_class_name,
-    "class" => "govuk-select",
-    'taxonomy' => $taxonomy_name,
-    'show_option_all' => "Select option",
-    'depth' => 1,
-    'orderby' => 'name',
-    'order' => 'ASC',
-    'hierarchical' => 1,
-    'selected' => $selected_topic,
-    'exclude' => $dropdown_exclude
-];
-
-$filter_label = $taxonomy->labels->singular_name;
-
-if(isset($taxonomy->labels->listing_page_filter) && !empty($taxonomy->labels->listing_page_filter)){
-    $filter_label = $taxonomy->labels->listing_page_filter;
-}
-
-if($taxonomy_name == "category"){
-    $filter_label = "Topic";
-}
-
-echo '<label class="govuk-label" for="' . esc_attr($parent_class_name) . '">' . esc_html($filter_label) . '</label>';
-wp_dropdown_categories($dropdown_args);
 
 $all_terms = get_terms(array(
     'taxonomy' => $taxonomy_name,
@@ -82,7 +50,6 @@ $all_terms = get_terms(array(
 ));
 
 $has_subtopics = false;
-
 foreach ($all_terms as $term) {
     if ($term->parent > 0) {
         $has_subtopics = true;
@@ -90,7 +57,62 @@ foreach ($all_terms as $term) {
     }
 }
 
-if ($has_subtopics) {
+// Get selected term name for autocomplete
+$selected_term_name = '';
+if ($selected_topic && is_numeric($selected_topic)) {
+    $term = get_term($selected_topic);
+    if ($term && !is_wp_error($term)) {
+        $selected_term_name = $term->name;
+    }
+}
+
+// Get filter label
+$filter_label = $taxonomy->labels->singular_name;
+if (isset($taxonomy->labels->listing_page_filter) && !empty($taxonomy->labels->listing_page_filter)) {
+    $filter_label = $taxonomy->labels->listing_page_filter;
+}
+if ($taxonomy_name == "category") {
+    $filter_label = "Topic";
+}
+
+echo '<label class="govuk-label" for="' . esc_attr($parent_class_name) . '">' . esc_html($filter_label) . '</label>';
+
+// Determine if autocomplete is turned on for a taxonomy
+$is_autocomplete_enabled = $taxonomy->autocomplete ?? false;
+
+if ($is_autocomplete_enabled) {
+    // Use autocomplete
+    get_template_part('template-parts/flexible-cpts/autocomplete-filter', false, [
+        'taxonomy-name' => $taxonomy_name,
+        'taxonomy' => $taxonomy,
+        'selected-topic' => $selected_topic,
+        'has-subtopics' => $has_subtopics,
+        'child-class-name' => $child_class_name,
+        'subtopic-query-var' => $subtopic_query_var,
+        'dropdown-exclude' => $dropdown_exclude,
+        'selected-term-name' => $selected_term_name
+    ]);
+} else {
+    // Use dropdown
+    $dropdown_args = [
+        "name" => $taxonomy->query_var,
+        "id" => $parent_class_name,
+        "class" => "govuk-select",
+        'taxonomy' => $taxonomy_name,
+        'show_option_all' => "Select option",
+        'depth' => 1,
+        'orderby' => 'name',
+        'order' => 'ASC',
+        'hierarchical' => 1,
+        'selected' => $selected_topic,
+        'exclude' => $dropdown_exclude
+    ];
+
+    wp_dropdown_categories($dropdown_args);
+}
+
+// SUBTOPIC HANDLING (only show if autocomplete is NOT enabled, or handle in template)
+if ($has_subtopics && !$is_autocomplete_enabled) {
     $disabled_subtopics = 'disabled="disabled"';
     $subtopic_wrapper_classes = 'govuk-visually-hidden';
 
@@ -110,18 +132,15 @@ if ($has_subtopics) {
     }
 
     $subfilter_label = 'Sub ' . $taxonomy->labels->singular_name;
-
-    if(isset($taxonomy->labels->listing_page_subfilter) && !empty($taxonomy->labels->listing_page_subfilter)){
+    if (isset($taxonomy->labels->listing_page_subfilter) && !empty($taxonomy->labels->listing_page_subfilter)) {
         $subfilter_label = $taxonomy->labels->listing_page_subfilter;
     }
-
-    if($taxonomy_name == "category"){
+    if ($taxonomy_name == "category") {
         $subfilter_label = "Sub-topic";
     }
 
-
     $wrapper_id = $child_class_name . '-wrapper';
-    
+
     echo '<div id="' . $wrapper_id . '" class="' . $subtopic_wrapper_classes . '">';
     echo '<label class="govuk-label" for="' . esc_attr($child_class_name) . '">' . esc_html($subfilter_label) . '</label>';
     echo '<select name="' . esc_attr($subtopic_query_var) . '" id="' . esc_attr($child_class_name) . '" class="govuk-select filter-subtopic" ' . $disabled_subtopics . '>';
@@ -135,4 +154,3 @@ if ($has_subtopics) {
     echo '</select>';
     echo '</div>';
 }
-

--- a/template-parts/flexible-cpts/taxonomy-filter.php
+++ b/template-parts/flexible-cpts/taxonomy-filter.php
@@ -43,7 +43,6 @@ if (is_array($restrict_terms) && !empty($restrict_terms)) {
     }
 }
 
-
 $all_terms = get_terms(array(
     'taxonomy' => $taxonomy_name,
     'hide_empty' => false,
@@ -68,6 +67,7 @@ if ($selected_topic && is_numeric($selected_topic)) {
 
 // Get filter label
 $filter_label = $taxonomy->labels->singular_name;
+
 if (isset($taxonomy->labels->listing_page_filter) && !empty($taxonomy->labels->listing_page_filter)) {
     $filter_label = $taxonomy->labels->listing_page_filter;
 }
@@ -77,7 +77,7 @@ if ($taxonomy_name == "category") {
 
 echo '<label class="govuk-label" for="' . esc_attr($parent_class_name) . '">' . esc_html($filter_label) . '</label>';
 
-// Determine if autocomplete is turned on for a taxonomy
+//Determines if the ACF toggle on a taxonomy is turned on
 $is_autocomplete_enabled = $taxonomy->autocomplete ?? false;
 
 if ($is_autocomplete_enabled) {
@@ -90,7 +90,8 @@ if ($is_autocomplete_enabled) {
         'child-class-name' => $child_class_name,
         'subtopic-query-var' => $subtopic_query_var,
         'dropdown-exclude' => $dropdown_exclude,
-        'selected-term-name' => $selected_term_name
+        'selected-term-name' => $selected_term_name,
+        'selected-sub-topic' => $selected_sub_topic
     ]);
 } else {
     // Use dropdown


### PR DESCRIPTION
This PR adds an autocomplete filter by taxonomy to the listing template. This is controlled via ACF. 

PR breakdown:
- Adds a toggle in the backend of ACF on a taxonomy that switches autocomplete on or off.
- When toggled on, any listing template filter using that taxonomy will switch to use an autocomplete filter.
- Uses same Gov UK css
- Introduces a new JS file just for using autocomplete on the listing template. 
- Uses same vars passed into the existing filter group.
- Minor formatting or PSR12

Still to do (part 2)
- Tidy up the look of the autocomplete field - arrow too big.
- While some work has been done on subtopics already, there is still some work to do to get it fully working.
