### PR TITLE
Separation of values with missing space

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.29.2
+Version: 4.29.3
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice

--- a/template-parts/flexible-cpts/details.php
+++ b/template-parts/flexible-cpts/details.php
@@ -65,7 +65,7 @@
                 ?>
                 <div class="flexible-post-type-detail">
                     <div class="flexible-post-type-detail-label"><?php echo $tax['label'];?>: </div>
-                    <?php echo implode("," , $term_names); ?>
+                    <?php echo implode("; " , $term_names); ?>
                 </div>
                 <?php
             }


### PR DESCRIPTION
## What does this pull request do?

Adds a space betwixt the items in the list and changes the comma to a semi-colon.

i.e.
before: `item A,item B,item C`
now: `item A; item B; item C`

## What is the new Hale version number?

4.29.3

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

