### PR TITLE
Cookie banner fix

### DIFF
--- a/assets/scss/brandings-cookies.scss
+++ b/assets/scss/brandings-cookies.scss
@@ -23,12 +23,14 @@
 		@extend #save-cookies-button;
 	}
 	a {
-		color: var(--link);
-		-webkit-text-fill-color: var(--link);
-
-		&:hover {
-			color: var(--link-hover);
-			-webkit-text-fill-color: var(--link-hover);
+		@media screen and (prefers-color-scheme: dark) {
+			color: var(--link);
+			-webkit-text-fill-color: var(--link);
+	
+			&:hover {
+				color: var(--link-hover);
+				-webkit-text-fill-color: var(--link-hover);
+			}
 		}
 
 		&:focus {

--- a/assets/scss/brandings-cookies.scss
+++ b/assets/scss/brandings-cookies.scss
@@ -23,7 +23,7 @@
 		@extend #save-cookies-button;
 	}
 	a {
-		@media screen and (prefers-color-scheme: dark) {
+		@media screen and not (prefers-color-scheme: dark) {
 			color: var(--link);
 			-webkit-text-fill-color: var(--link);
 	

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.34.2
+Version: 4.34.3
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

It sets the cookie banner link text to only apply in light mode, to fix contrast issues

## What is the new Hale version number?

v4.34.3

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [ ] Checked on a mobile device
- [x] Checked on a desktop device
- [ ] Checked on Safari
- [ ] Checked on Firefox
- [x] Checked on Chrome

## Notes

