### PR TITLE
Force Admin interface to api v2 to fix backend styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -595,3 +595,21 @@ require get_template_directory() . '/inc/helper-functions.php';
  * Extend API with custom post type info
  */
 require get_template_directory() . '/inc/api-extensions.php';
+
+// Disables Iframe Editor - Temp fix 
+// Wordpress previosuly disabled the iframe editor across the whole site if blocks were using v2 api 
+// Since Wordpress 7.0.0 its on a page by page basis
+// This means editor styles/fonts are not loading into the iframe.
+add_action( 'enqueue_block_editor_assets', function () {
+	wp_add_inline_script(
+		'wp-blocks',
+		"wp.hooks.addFilter(
+			'blocks.registerBlockType',
+			'hale/debug-no-iframe',
+			function ( settings ) {
+				return Object.assign( {}, settings, { apiVersion: 2 } );
+			}
+		);",
+		'after'
+	);
+} );

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.34.7
+Version: 4.34.8
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Disables Iframe Editor - Temp fix 
Wordpress previosuly disabled the iframe editor across the whole site if blocks were using v2 api 
Since Wordpress 7.0.0 its on a page by page basis
This means editor styles/fonts are not loading into the iframe.

## What is the new Hale version number?

4.34.8

## Is the change available on the Dev or Demo environments?

Dev

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [x] Checked on Firefox
- [x] Checked on Chrome

## Notes

We need to change our theme/blocks to load styles in v3way so it works with iframes. this is only a temp fix