### PR TITLE
Remove Heading block variants being unregistered and disable fit text

### DIFF
--- a/assets/js/restrict-embed-blocks.js
+++ b/assets/js/restrict-embed-blocks.js
@@ -50,12 +50,4 @@ wp.domReady(function () {
     }
   });
 
-  wp.blocks.getBlockVariations('core/heading').forEach(function (blockVariation) {
-      wp.blocks.unregisterBlockVariation('core/heading', blockVariation.name);
-  });
-
-   wp.blocks.getBlockVariations('core/paragraph').forEach(function (blockVariation) {
-      wp.blocks.unregisterBlockVariation('core/paragraph', blockVariation.name);
-  });
-    
 });

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -118,3 +118,13 @@ function hale_get_allowed_blocks(){
 
     return $allowed_blocks;
 }
+
+add_filter( 'block_type_metadata', function ( array $metadata ) {
+
+    if ( in_array( $metadata['name'], [ 'core/heading', 'core/paragraph' ], true ) ) {
+        $metadata['supports']['typography']['fitText'] = false;
+    }
+
+    return $metadata;
+
+} );

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 4.35.0
+Version: 4.35.1
 Domain Path: /languages
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice


### PR DESCRIPTION
## What does this pull request do?

Remove Heading block variants being unregistered and disable fit text

In Wordpress 7.0.2 it uses variants of the heading block for heading sizes e.g. h2 h3 h4

We originally unregistered variants as to prevent use of the stretchy heading and paragraph blocks but this has now moved to a fit text setting. 

## What is the new Hale version number?

4.35.1

## Is the change available on the Dev or Demo environments?

Neither.

## Checklist

- [x] Checked on a mobile device
- [x] Checked on a desktop device
- [x] Checked on Safari
- [x] Checked on Firefox
- [x] Checked on Chrome

## Notes

